### PR TITLE
Wiki: pretvorba še enkrat + poenotenje z že narejenimi popravki.

### DIFF
--- a/src/wiki/a-okvir.md
+++ b/src/wiki/a-okvir.md
@@ -1,13 +1,5 @@
 # A-okvir
 
-_A-okvir_ je podporna struktura, s katero odmaknemo
-[skupno točko](/skupna-tocka) [sidrišča](/sidrisce) od tal, da preprečimo
-[abrazijo](/abrazija) ter olajšamo dostop do izhodišča [visokice](/visokica).
-Uporabimo ga, kadar so sidriščne točke bodisi precej odmaknjene od krajišča
-[visokice](/visokica) bodisi se nahajajo zelo blizu tal (ali celo na tleh).
-A-okvir je najpogosteje izdelan iz treh lesenih tramov, zbitih v obliko črke A:
-pokončni stranici stojita na tleh, prečna povezava pa drži celo strukturo trdno.
-Skupna točka sidrišča je nameščena v prostor med njimi, podpira jo statična vrv,
-napeljana preko vrha ter stranic okvirja.
+_A-okvir_ je podporna struktura, s katero odmaknemo [skupno točko](skupna-tocka) [sidrišča](sidrisce) od tal, da preprečimo [abrazijo](abrazija) ter olajšamo dostop do izhodišča [visokice](visokica). Uporabimo ga, kadar so sidriščne točke bodisi precej odmaknjene od krajišča [visokice](visokica) bodisi se nahajajo zelo blizu tal (ali celo na tleh). A-okvir je najpogosteje izdelan iz treh lesenih tramov, zbitih v obliko črke A: pokončni stranici stojita na tleh, prečna povezava pa drži celo strukturo trdno. Skupna točka sidrišča je nameščena v prostor med njimi, podpira jo statična vrv, napeljana preko vrha ter stranic okvirja.
 
 ![A-okvir](images/aokvir.jpg)

--- a/src/wiki/abrazija.md
+++ b/src/wiki/abrazija.md
@@ -1,28 +1,7 @@
 # Abrazija
 
-_Abrazija_ je obraba, do katere pride zaradi drgnjenja. Možnost za abrazijo
-obstaja povsod, kjer imamo trenje med dvema medsebojno gibajočima se predmetoma.
-Prizadene predvsem elemente, izdelane iz mehkejših materialov, na primer
-[trakove](/trak), [zanke](/neskoncna-zanka) in vrvi, niso pa pred njo povsem
-varni tudi kovinski elementi. Do abrazije lahko pride hipno, če sta predmeta
-izpostavljena veliki sili in sunkovitemu premiku, lahko pa napreduje tudi
-počasi, z manj intenzivnim, a ponavljajočim se drgnjenjem. Abrazija lahko
-povzroči popolno odpoved opreme, zato jo je treba na vsak način preprečiti, kar
-dosežemo s [podlaganjem](/podloga) in [odmikanjem](/A-okvir).
+_Abrazija_ je obraba, do katere pride zaradi drgnjenja. Možnost za abrazijo obstaja povsod, kjer imamo trenje med dvema medsebojno gibajočima se predmetoma. Prizadene predvsem elemente, izdelane iz mehkejših materialov, na primer [trakove](trak), [zanke](neskoncna-zanka) in vrvi, niso pa pred njo povsem varni tudi kovinski elementi. Do abrazije lahko pride hipno, če sta predmeta izpostavljena veliki sili in sunkovitemu premiku, lahko pa napreduje tudi počasi, z manj intenzivnim, a ponavljajočim se drgnjenjem. Abrazija lahko povzroči popolno odpoved opreme, zato jo je treba na vsak način preprečiti, kar dosežemo s [podlaganjem](podloga) in [odmikanjem](a-okvir).
 
-Pri [visokicah](/visokica) so nevarnosti abrazije izpostavljene predvsem
-komponente v [sidriščih](/sidrisce); najpogosteje gre za drgnjenje
-[tovornih zank](/tovorna-zanka) ali vrvi ob skale. Abrazivni poškodbi sta lahko
-izpostavljena tudi trakova visokice, če se ob obremenitvi prevesita preko
-ostrega skalnega roba.
+Pri [visokicah](visokica) so nevarnosti abrazije izpostavljene predvsem komponente v [sidriščih](sidrisce); najpogosteje gre za drgnjenje [tovornih zank](tovorna-zanka) ali vrvi ob skale. Abrazivni poškodbi sta lahko izpostavljena tudi trakova visokice, če se ob obremenitvi prevesita preko ostrega skalnega roba.
 
-Do posebnega primera abrazije pride pri medsebojnem drgnjenju vrvi ali trakov,
-na primer če daljši kos vrvi vlečemo preko druge vrvi. Zaradi trenja stična
-točka doseže temperature, ki so dovolj visoke, da stalijo vlakna v vrvi in tako
-povzročijo poškodbo. Na to vrsto abrazije so zlasti občutljivi izdelki iz
-[UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (Dyneema), saj ima ta material
-zelo nizko tališče. V dvomu se situacijam, kjer bi prišlo do medsebojnega
-drgnjenja tekstilnih izdelkov, raje odpovemo. Statično obremenjena stična mesta,
-na primer povezava dveh [šivanih zank](/sivana-zanka) z
-[vrvnim škopcem](/vrvni-skopec), niso problematična, saj je medsebojno gibanje
-na takem stiku zanemarljivo.
+Do posebnega primera abrazije pride pri medsebojnem drgnjenju vrvi ali trakov, na primer če daljši kos vrvi vlečemo preko druge vrvi. Zaradi trenja stična točka doseže temperature, ki so dovolj visoke, da stalijo vlakna v vrvi in tako povzročijo poškodbo. Na to vrsto abrazije so zlasti občutljivi izdelki iz [UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (Dyneema), saj ima ta material zelo nizko tališče. V dvomu se situacijam, kjer bi prišlo do medsebojnega drgnjenja tekstilnih izdelkov, raje odpovemo. Statično obremenjena stična mesta, na primer povezava dveh [šivanih zank](sivana-zanka) z [vrvnim škopcem](vrvni-skopec), niso problematična, saj je medsebojno gibanje na takem stiku zanemarljivo.

--- a/src/wiki/banana.md
+++ b/src/wiki/banana.md
@@ -1,59 +1,19 @@
 # Banana
 
-_Banana_[^1] je pripomoček, v katerega vpnemo [trak](/trak), da ga lahko
-pritrdimo na [sidrišče](/sidrisce). Sestavljena je iz kovinskega ogrodja, v
-katerega sta vpeti dve osi, ena na prednji strani banane in druga v sredini.
-Prednja os je tanjša in odstranljiva, osrednja pa debelejša in nepremična.
-Zadnja stran banane je oblikovana v uho ali prečko in služi za pritrditev v
-sidrišče.
+_Banana_[^1] je pripomoček, v katerega vpnemo [trak](trak), da ga lahko pritrdimo na [sidrišče](sidrisce). Sestavljena je iz kovinskega ogrodja, v katerega sta vpeti dve osi, ena na prednji strani banane in druga v sredini. Prednja os je tanjša in odstranljiva, osrednja pa debelejša in nepremična. Zadnja stran banane je oblikovana v uho ali prečko in služi za pritrditev v sidrišče.
 
-[^1]: Izraz izvira iz časov zgodnjih različic tega pripomočka, ki so po obliki
-    spominjale na banano. Sodobne izvedbe so lahko precej drugačnih oblik, zato
-    asociacija dostikrat ni več očitna, izraz pa se je vseeno ohranil.
+[^1]: Izraz izvira iz časov zgodnjih različic tega pripomočka, ki so po obliki spominjale na banano. Sodobne izvedbe so lahko precej drugačnih oblik, zato asociacija dostikrat ni več očitna, izraz pa se je vseeno ohranil.
 
-Trak v banano vpnemo tako, da ga najprej na želenem mestu preganemo v zanko;
-pramen traku, ki ga kanimo obremeniti, leži zgoraj. Zanko ovijemo za skoraj poln
-ovoj okoli osrednje osi banane, nato pa odstranimo prednjo os in jo namestimo
-nazaj tako, da poteka skozi vrh zanke. Banana trak zadrži zaradi trenja med
-pramenoma v zanki: zunanji pramen traku ob obremenitvi stisne notranjega ob
-osrednjo os ter s tem prepreči zdrs. Drsenje v drugi smeri je še vedno mogoče,
-kar s pridom izkoriščamo za to, da z potegom neobremenjenega pramena odstranimo
-odvečen trak iz sistema.
+Trak v banano vpnemo tako, da ga najprej na želenem mestu preganemo v zanko; pramen traku, ki ga kanimo obremeniti, leži zgoraj. Zanko ovijemo za skoraj poln ovoj okoli osrednje osi banane, nato pa odstranimo prednjo os in jo namestimo nazaj tako, da poteka skozi vrh zanke. Banana trak zadrži zaradi trenja med pramenoma v zanki: zunanji pramen traku ob obremenitvi stisne notranjega ob osrednjo os ter s tem prepreči zdrs. Drsenje v drugi smeri je še vedno mogoče, kar s pridom izkoriščamo za to, da z potegom neobremenjenega pramena odstranimo odvečen trak iz sistema.
 
-Na [visokicah](/visokica) banano namestimo na
-[napenjalni strani](/napenjalna-stran), na statični pa zaradi prihranka pri masi
-opreme običajno raje uporabimo [šivano zanko](/sivana-zanka). V kombinaciji z
-[mačkom](/macek) in [primežem](/primez) banana služi tudi kot preprost
-[napenjalni sistem](/napenjalni-sistem), s katerim lahko z relativno malo truda
-dosežemo [napetosti](/napetost) do približno 3 kN, kar je za večino visokic
-povsem dovolj. Za večje sile ali napenjanje z manj truda lahko z dodatnimi mački
-učinkovitost takega napenjalnega sistema še povečamo.
+Na [visokicah](visokica) banano namestimo na [napenjalni strani](napenjalna-stran), na statični pa zaradi prihranka pri masi opreme običajno raje uporabimo [šivano zanko](sivana-zanka). V kombinaciji z [mačkom](macek) in [primežem](primez) banana služi tudi kot preprost [napenjalni sistem](napenjalni-sistem), s katerim lahko z relativno malo truda dosežemo [napetosti](napetost) do približno 3 kN, kar je za večino visokic povsem dovolj. Za večje sile ali napenjanje z manj truda lahko z dodatnimi mački učinkovitost takega napenjalnega sistema še povečamo.
 
-Banane so na razpolago v mnogih različicah, ki se razlikujejo po velikosti,
-teži, zagotovljeni [minimalni porušni sili](/minimalna-porusna-sila) ter
-posebnih značilnostih, ki olajšajo njihovo uporabo. Med slednjimi so, na primer:
+Banane so na razpolago v mnogih različicah, ki se razlikujejo po velikosti, teži, zagotovljeni [minimalni porušni sili](minimalna-porusna-sila) ter posebnih značilnostih, ki olajšajo njihovo uporabo. Med slednjimi so, na primer:
 
-- votla osrednja os, ki jo je moč izkoristiti pri blokiranju prostega dela
-  traku;
-- pritrdilna točka za škripčevje na prednji strani;
-- odstranljiva prečka na zadnji strani, ki lahko služi kot os
-  [popuščalke](/popuscalka).
+* votla osrednja os, ki jo je moč izkoristiti pri blokiranju prostega dela traku;
+* pritrdilna točka za škripčevje na prednji strani;
+* odstranljiva prečka na zadnji strani, ki lahko služi kot os [popuščalke](popuscalka).
 
-Z varnostnega stališča je najpomembnejša značilnost banane premer njene osrednje
-osi. Če je ta dovolj debela, se vpeti trak okoli nje zakrivi zelo polagoma in s
-tem ohrani praktično polno [minimalno porušno silo](/minimalna-porusna-sila),
-kar je zlasti pomembno na [visokicah](/visokica).
+Z varnostnega stališča je najpomembnejša značilnost banane premer njene osrednje osi. Če je ta dovolj debela, se vpeti trak okoli nje zakrivi zelo polagoma in s tem ohrani praktično polno [minimalno porušno silo](minimalna-porusna-sila), kar je zlasti pomembno na [visokicah](visokica).
 
-Edina slaba lastnost banane, ki pa jo je z ustreznimi ukrepi mogoče povsem
-izničiti, je _drsenje repa_. To je pojav, do katerega pride ob obremenitvah, pri
-katerih je trak podvržen ciklom raztegovanja in krčenja (zaradi hoje,
-poskakovanja, padcev, vetra ...). Drobni raztegi traku, ovitega okoli osrednje
-osi, počasi vlečejo neobremenjeni konec (t.i. _rep_) v banano. Če rep ni speljan
-povsem po sredini banane, se lahko zaviha čez njen rob in zaradi drsenja se
-sčasoma odvije zunanji ovoj traku. S tem vpetje nenadoma popolnoma popusti.
-Drsenje repa lahko povsem preprečimo tako, da neobremenjeni konec traku speljemo
-nazaj po spodnji strani banani in ga trdno zavežemo okoli nje, običajno s
-kombinacijo več ovojev in bičevega vozla. Pri tem je lahko v pomoč tudi sama
-oblika banane, na primer votla osrednja os, skozi katero potegnemo zanko repa,
-preden jo privežemo. Blokada repa je izredno pomembna in je na visokicah
-_nikoli_ ne smemo opustiti.
+Edina slaba lastnost banane, ki pa jo je z ustreznimi ukrepi mogoče povsem izničiti, je _drsenje repa_. To je pojav, do katerega pride ob obremenitvah, pri katerih je trak podvržen ciklom raztegovanja in krčenja (zaradi hoje, poskakovanja, padcev, vetra ...). Drobni raztegi traku, ovitega okoli osrednje osi, počasi vlečejo neobremenjeni konec (t.i. _rep_) v banano. Če rep ni speljan povsem po sredini banane, se lahko zaviha čez njen rob in zaradi drsenja se sčasoma odvije zunanji ovoj traku. S tem vpetje nenadoma popolnoma popusti. Drsenje repa lahko povsem preprečimo tako, da neobremenjeni konec traku speljemo nazaj po spodnji strani banani in ga trdno zavežemo okoli nje, običajno s kombinacijo več ovojev in bičevega vozla. Pri tem je lahko v pomoč tudi sama oblika banane, na primer votla osrednja os, skozi katero potegnemo zanko repa, preden jo privežemo. Blokada repa je izredno pomembna in je na visokicah _nikoli_ ne smemo opustiti.

--- a/src/wiki/bicev-vozel.md
+++ b/src/wiki/bicev-vozel.md
@@ -1,6 +1,5 @@
 # Bičev vozel
 
-_Bičev vozel_ pri visokovanju uporabljamo za različne pritrditve delovnih in
-pomožnih vrvi ter zank. Je zelo uporaben vozel.
+_Bičev vozel_ pri visokovanju uporabljamo za različne pritrditve delovnih in pomožnih vrvi ter zank. Je zelo uporaben vozel.
 
 [Bičev vozel v alpiročniku](https://alpirocnik.rasica.org/wiki/Vrvi,_vozli_in_njihova_uporaba#Bi.C4.8Dev_vozel)

--- a/src/wiki/deltasti-clen.md
+++ b/src/wiki/deltasti-clen.md
@@ -1,13 +1,5 @@
 # Deltasti člen
 
-_Deltasti člen_ je kovinski vezni člen trikotne oblike, ki se na eni od stranic
-zapira z matico. Uporabljamo ga pri izdelavi skalnih [sidrišč](/sidrisce), na
-katerih so sidriščne točke v [skupno točko](/skupna-tocka) povezane s
-[tovornimi zankami](/tovorna-zanka). V takem primeru je v uho vsakega skalnega
-vijaka vstavljen po en deltasti člen, skozi tega pa je nato vstavljena zanka.
+_Deltasti člen_ je kovinski vezni člen trikotne oblike, ki se na eni od stranic zapira z matico. Uporabljamo ga pri izdelavi skalnih [sidrišč](sidrisce), na katerih so sidriščne točke v [skupno točko](skupna-tocka) povezane s [tovornimi zankami](tovorna-zanka). V takem primeru je v uho vsakega skalnega vijaka vstavljen po en deltasti člen, skozi tega pa je nato vstavljena zanka.
 
-Pred obremenitvijo je treba na členu vedno priviti matico. Odprt člen ima mnogo
-manjšo nosilnost od zaprtega, zato ob obremenitvi odprtega lahko pride do
-deformacije ali celo popolne odpovedi. Prav tako pomembno je, da matico
-zategnemo s ključem, saj privijanje samo z roko pogosto ni dovolj in se matica
-ob vibracijah sčasoma lahko sama odvije.
+Pred obremenitvijo je treba na členu vedno priviti matico. Odprt člen ima mnogo manjšo nosilnost od zaprtega, zato ob obremenitvi odprtega lahko pride do deformacije ali celo popolne odpovedi. Prav tako pomembno je, da matico zategnemo s ključem, saj privijanje samo z roko pogosto ni dovolj in se matica ob vibracijah sčasoma lahko sama odvije.

--- a/src/wiki/dvig-na-trak.md
+++ b/src/wiki/dvig-na-trak.md
@@ -1,29 +1,21 @@
 # Dvig na trak
 
-_Dvig na trak_ iz visečega položaja je ena od osnovnih osnovnih veščin,
-potrebnih za visokovanje. Manevra se velja dobro naučiti, da nam pri visokovanju
-pobere čim manj energije. Vaditi ga je mogoče v parku, le trak mora biti napet
-dovolj visoko, da se pri vadbi ne zadenemo v tla.
+_Dvig na trak_ iz visečega položaja je ena od osnovnih osnovnih veščin, potrebnih za visokovanje. Manevra se velja dobro naučiti, da nam pri visokovanju pobere čim manj energije. Vaditi ga je mogoče v parku, le trak mora biti napet dovolj visoko, da se pri vadbi ne zadenemo v tla.
 
 ## Postopek
 
-Izhodiščni položaj za dvig je, da se za trak držimo z obema rokama, stopalo ene
-noge pa za trak zataknemo tik nad peto (trak leži na Ahilovi tetivi). Zataknjeno
-nogo pokrčimo v kolenu, da sta stegno in golen približno pravokotni. Celo telo
-nato potegnemo čim bliže traku, prosto nogo pa iztegnemo vstran, pravokotno na
-trak. Če je položaj pravilen, nas teža iztegnjene noge začne sukati in čez nekaj
-trenutkov se znajdemo v ležečem položaju na traku. Obe nogi nato spustimo in se
-z rokami potisnemo v sedeč položaj.
+Izhodiščni položaj za dvig je, da se za trak držimo z obema rokama, stopalo ene noge pa za trak zataknemo tik nad peto (trak leži na Ahilovi tetivi). Zataknjeno nogo pokrčimo v kolenu, da sta stegno in golen približno pravokotni. Celo telo nato potegnemo čim bliže traku, prosto nogo pa iztegnemo vstran, pravokotno na trak. Če je položaj pravilen, nas teža iztegnjene noge začne sukati in čez nekaj trenutkov se znajdemo v ležečem položaju na traku. Obe nogi nato spustimo in se z rokami potisnemo v sedeč položaj.
 
 ## Začetniške napake
 
-Manever je, ko ga opravi izkušen človek, videti povsem preprost in tak tudi v
-resnici je - a mučenje z začetnimi poskusi vseeno marsikoga prepriča v
-nasprotno. V pomoč naj navedemo nekaj najpogostejših začetniških napak:
+Manever je, ko ga opravi izkušen človek, videti povsem preprost in tak tudi v resnici je – a mučenje z začetnimi poskusi vseeno marsikoga prepriča v nasprotno. V pomoč naj navedemo nekaj najpogostejših začetniških napak:
 
-- Daleč najpogostejša napaka je, da telesa ne dovolj približamo traku
-  S tem teža trupa nasprotuje teži iztegnjene noge in do obrata ne pride. Za uspešen obrat je torej *nujno*, da smo povsem "prilepljeni" na trak. Boke naj dviguje predvsem za trak zataknjena noga, zgornji del telesa pa roke. Priporočljivo je, da roki nekoliko razmaknemo po traku: ena naj bo pri vrhu prsnega koša, druga pa na njegovi sredini. V nasprotju s prepričanjem začetnikov za dvig *ni* potrebna izjemna moč v rokah, saj moramo z njimi dvigniti le zgornjo polovico telesa, poleg tega pa je treba v dvignjenem položaju vztrajati le zelo kratek čas.
-- Zamah z iztegnjeno nogo je pri učenju bolj v napoto kot v korist, saj tako zanihamo trak in se nanj poskušamo obrniti ravno takrat, ko nam je nihaj najbolj v oviro. Manever dviga je mogoče izvesti povsem zvezno in počasi, in priporočamo, da se ga začetniki in začetnice tako tudi naučijo. Ko enkrat obvladamo statično različico, bo z vajo telo samo ugotovilo, katerem gibu se splača dodati nekaj dinamike, da bo izvedba še lažja.
-- Če nam uspe le prva polovica obrata, nato pa nas prevrne nazaj pod trak, smo najverjetneje v pričakovanju skorajšnjega zaključka pokrčili iztegnjeno nogo ali pa smo jo sicer ohranili iztegnjeno, toda približali traku. S tem njena teža nima več dovoljšnjega vzvoda, da bi nas obrnila. Noga mora ostati iztegnjena ves čas, in mora biti tudi ves čas pravokotna na trak. Pokrčiti jo smemo šele, ko lahko težo svojega telesa položimo neposredno na trak.
-- Marsikateremu začetniku ali začetnici se zdi bolj intuitivno, da bi se z nogo preko traku obesil tako, da trak poteka pod kolenom namesto pod peto. Četudi se je v tem položaju mogoče uspešno obrniti, ga ne priporočamo, saj močan pritisk traku na mehko kožo pod kolenom že pri enem samem poskusu navadno povzroči spektakularne podplutbe. Ahilova tetiva je na pritisk bistveno bolj odporna.
-- Ljudje z veliko moči v rokah - tipično tisti, ki se ukvarjajo tudi s plezanjem - po spodletelem poskusu ali dvema radi obupajo in se odločijo, da se bodo na trak raje povzpeli kar z golo silo, kot bi se dvigovali na skalno polico. To seveda deluje, a pobere ogromno energije. Predlagamo, da prednost svoje moči raje izkoristijo tako, da si dovolijo več poskusov, in uspeh zagotovo ne bo izostal.
+* Daleč najpogostejša napaka je, da telesa ne dovolj približamo traku. S tem teža trupa nasprotuje teži iztegnjene noge in do obrata ne pride. Za uspešen obrat je torej *nujno*, da smo povsem "prilepljeni" na trak. Boke naj dviguje predvsem za trak zataknjena noga, zgornji del telesa pa roke. Priporočljivo je, da roki nekoliko razmaknemo po traku: ena naj bo pri vrhu prsnega koša, druga pa na njegovi sredini. V nasprotju s prepričanjem začetnikov za dvig *ni* potrebna izjemna moč v rokah, saj moramo z njimi dvigniti le zgornjo polovico telesa, poleg tega pa je treba v dvignjenem položaju vztrajati le zelo kratek čas.
+
+* Zamah z iztegnjeno nogo je pri učenju bolj v napoto kot v korist, saj tako zanihamo trak in se nanj poskušamo obrniti ravno takrat, ko nam je nihaj najbolj v oviro. Manever dviga je mogoče izvesti povsem zvezno in počasi, in priporočamo, da se ga začetniki in začetnice tako tudi naučijo. Ko enkrat obvladamo statično različico, bo z vajo telo samo ugotovilo, katerem gibu se splača dodati nekaj dinamike, da bo izvedba še lažja.
+
+* Če nam uspe le prva polovica obrata, nato pa nas prevrne nazaj pod trak, smo najverjetneje v pričakovanju skorajšnjega zaključka pokrčili iztegnjeno nogo ali pa smo jo sicer ohranili iztegnjeno, toda približali traku. S tem njena teža nima več dovoljšnjega vzvoda, da bi nas obrnila. Noga mora ostati iztegnjena ves čas, in mora biti tudi ves čas pravokotna na trak. Pokrčiti jo smemo šele, ko lahko težo svojega telesa položimo neposredno na trak.
+
+* Marsikateremu začetniku ali začetnici se zdi bolj intuitivno, da bi se z nogo preko traku obesil tako, da trak poteka pod kolenom namesto pod peto. Četudi se je v tem položaju mogoče uspešno obrniti, ga ne priporočamo, saj močan pritisk traku na mehko kožo pod kolenom že pri enem samem poskusu navadno povzroči spektakularne podplutbe. Ahilova tetiva je na pritisk bistveno bolj odporna.
+
+* Ljudje z veliko moči v rokah – tipično tisti, ki se ukvarjajo tudi s plezanjem – po spodletelem poskusu ali dvema radi obupajo in se odločijo, da se bodo na trak raje povzpeli kar z golo silo, kot bi se dvigovali na skalno polico. To seveda deluje, a pobere ogromno energije. Predlagamo, da prednost svoje moči raje izkoristijo tako, da si dovolijo več poskusov, in uspeh zagotovo ne bo izostal.

--- a/src/wiki/frostov-vozel.md
+++ b/src/wiki/frostov-vozel.md
@@ -1,36 +1,9 @@
 # Frostov vozel
 
-_Frostov vozel_ je način izdelave končne zanke v [traku](/trak) ali vrvi, s
-katerim ohranimo večji delež nosilnosti kot z običajno enojno zanko. Frostov
-vozel je v svoji osnovni obliki pravzaprav le vozel _šestica_, zavezan na
-specifičen način; lahko pa na isti način zavežemo tudi druge različice vozlov,
-npr. osmico ali devetko. V visokovanju se takšen vozel včasih uporablja kot
-nadomestilo za [šivano zanko](/sivana-zanka), a le v okoliščinah, kjer vozel ni
-trajno obremenjen, na primer na krajiščih [pomožnega traku](/pomozni-trak).
+_Frostov vozel_ je način izdelave končne zanke v [traku](trak) ali vrvi, s katerim ohranimo večji delež nosilnosti kot z običajno enojno zanko. Frostov vozel je v svoji osnovni obliki pravzaprav le vozel _šestica_, zavezan na specifičen način; lahko pa na isti način zavežemo tudi druge različice vozlov, npr. osmico ali devetko. V visokovanju se takšen vozel včasih uporablja kot nadomestilo za [šivano zanko](sivana-zanka), a le v okoliščinah, kjer vozel ni trajno obremenjen, na primer na krajiščih [pomožnega traku](pomozni-trak).
 
-Frostov vozel v traku zavežemo tako, da konec traku prepognemo, nato pa
-prepognjeni konec prepognemo ponovno, da dobimo štiri vzporedne pramene.[^1]
-Cel snop zavežemo v vozel in s tem dobimo zanko. Pred uporabo moramo vozel
-lepo poravnati in ga zategniti s tem, da dobro povlečemo vsak pramen
-posebej.
+Frostov vozel v traku zavežemo tako, da konec traku prepognemo, nato pa prepognjeni konec prepognemo ponovno, da dobimo štiri vzporedne pramene.[^1] Cel snop zavežemo v vozel in s tem dobimo zanko. Pred uporabo moramo vozel lepo poravnati in ga zategniti s tem, da dobro povlečemo vsak pramen posebej.
 
-[^1]: Mnenja o tem, ali mora pramen, ki ga bomo obremenili, potekati po
-    sredini ali po strani snopa, so deljena. Smiselno se zdi, da bi bila
-    nosilnost različice, kjer obremenjeni pramen poteka po strani, večja,
-    saj s tem dosežemo večji krivinski radij pramena, a izročilo priporoča
-    ravno nasprotno. Zaenkrat kaže, da rezultati [nadzorovanih
-    preizkusov](https://www.slacktivity.com/slackline-infos/slackline-webbing-knots)
-    podpirajo vezavo z obremenjenim pramenom na strani, a za razrešitev
-    dileme bo treba počakati na še kako potrditev.
+[^1]: Mnenja o tem, ali mora pramen, ki ga bomo obremenili, potekati po sredini ali po strani snopa, so deljena. Smiselno se zdi, da bi bila nosilnost različice, kjer obremenjeni pramen poteka po strani, večja, saj s tem dosežemo večji krivinski radij pramena, a izročilo priporoča ravno nasprotno. Zaenkrat kaže, da rezultati [nadzorovanih preizkusov](https://www.slacktivity.com/slackline-infos/slackline-webbing-knots) podpirajo vezavo z obremenjenim pramenom na strani, a za razrešitev dileme bo treba počakati na še kako potrditev.
 
-Zmanjšanje [minimalne porušne sile](/minimalna-porusna-sila) traku zaradi
-Frostovega vozla je odvisno od vrste traku in uporabljenega vozla. Iz
-previdnosti je treba računati z oceno, da Frostov vozel, zavezan v šestico,
-ohrani le okoli 50 % nosilnosti. Nekoliko boljši rezultat dobimo z osmico ali
-devetko. Največji problem nosilnosti Frostovih vozlov je njena velika
-variabilnost: vozli, zavezani z istim trakom ter v popolnoma enako vezavo, se
-lahko pretrgajo pri znatno različnih silah, ne da bi bilo iz njihovega videza
-mogoče vnaprej povedati, kateri bo močnejši in kateri šibkejši. Iz tega razloga
-se uporaba Frostovih vozlov v visokovanju počasi opušča v korist uporabe
-[banan](/banana), ki ohranjajo bistveno več nosilnosti traku in dajejo tudi
-mnogo bolj ponovljive rezultate.
+Zmanjšanje [minimalne porušne sile](minimalna-porusna-sila) traku zaradi Frostovega vozla je odvisno od vrste traku in uporabljenega vozla. Iz previdnosti je treba računati z oceno, da Frostov vozel, zavezan v šestico, ohrani le okoli 50 % nosilnosti. Nekoliko boljši rezultat dobimo z osmico ali devetko. Največji problem nosilnosti Frostovih vozlov je njena velika variabilnost: vozli, zavezani z istim trakom ter v popolnoma enako vezavo, se lahko pretrgajo pri znatno različnih silah, ne da bi bilo iz njihovega videza mogoče vnaprej povedati, kateri bo močnejši in kateri šibkejši. Iz tega razloga se uporaba Frostovih vozlov v visokovanju počasi opušča v korist uporabe [banan](banana), ki ohranjajo bistveno več nosilnosti traku in dajejo tudi mnogo bolj ponovljive rezultate.

--- a/src/wiki/glavni-trak.md
+++ b/src/wiki/glavni-trak.md
@@ -1,11 +1,3 @@
 # Glavni trak
 
-_Glavni trak_ je osrednji element [visokice](/visokica). [Napet](/napetost) je
-med dve [sidrišči](/sidrisce), eno na [napenjalni strani](/napenjalna-stran)
-(kjer je vpet v [banano](/banana)) in drugo na
-[statični strani](/staticna-stran) (kjer za vpenjanje običajno izkoristimo
-[šivano zanko](/sivana-zanka)). Pod glavnim trakom je v zankah obešen še
-[pomožni trak](/pomozni-trak), preko obeh pa sta nadeta kovinska obroča, na
-katera je privezan [vis](/vis). Na krajših visokicah uporabljamo glavni trak iz
-enega kosa, pri daljših pa ga lahko [sestavimo](/segmentiranje) iz več delov.
-Njegove [značilnosti](/trak) ključno vplivajo na karakter visokice.
+_Glavni trak_ je osrednji element [visokice](visokica). [Napet](napetost) je med dve [sidrišči](sidrisce), eno na [napenjalni strani](napenjalna-stran) (kjer je vpet v [banano](banana)) in drugo na [statični strani](staticna-stran) (kjer za vpenjanje običajno izkoristimo [šivano zanko](sivana-zanka)). Pod glavnim trakom je v zankah obešen še [pomožni trak](pomozni-trak), preko obeh pa sta nadeta kovinska obroča, na katera je privezan [vis](vis). Na krajših visokicah uporabljamo glavni trak iz enega kosa, pri daljših pa ga lahko [sestavimo](segmentiranje) iz več delov. Njegove [značilnosti](trak) ključno vplivajo na karakter visokice.

--- a/src/wiki/jebeno-velik-vozel.md
+++ b/src/wiki/jebeno-velik-vozel.md
@@ -1,20 +1,5 @@
 # Jebeno velik vozel
 
-_Jebeno velik vozel_ (kratica BFK, angl. _big fucking knot_) je en od načinov
-izdelave [skupne točke](/skupna-tocka) na [sidrišču](/sidrisce). Njegova
-prednost je, da ob morebitni odpovedi ene od sidriščnih točk ostalih ne
-izpostavi sunkoviti obremenitvi in s tem nevarnosti
-[verižne odpovedi](/verizna-odpoved). Njegova slaba stran pa je, da ne omogoča
-samodejnega porazdeljevanja obremenitve med sidriščne točke.
+_Jebeno velik vozel_ (kratica BFK, angl. _big fucking knot_) je en od načinov izdelave [skupne točke](skupna-tocka) na [sidrišču](sidrisce). Njegova prednost je, da ob morebitni odpovedi ene od sidriščnih točk ostalih ne izpostavi sunkoviti obremenitvi in s tem nevarnosti [verižne odpovedi](verizna-odpoved). Njegova slaba stran pa je, da ne omogoča samodejnega porazdeljevanja obremenitve med sidriščne točke.
 
-Z izdelavo jebeno velikega vozla pričnemo tako, da statično vrv najprej
-prevlečemo skozi vse sidriščne točke ter zvežemo njena konca (alternativno lahko
-konca pustimo viseti pri strani in ju zvežemo v vozel skupaj z ostalimi
-prameni). Nato povlečemo vsako povezavo med sosednjima sidriščnima točka, da
-nastane zanka, in nastale zanke združimo v skupni točki. Pridružimo še zanko, ki
-povezuje prvo sidriščno točko z zadnjo. Šop zank dobro potresemo, da porazdelimo
-vrv med pramene, nato pa ga zavežemo v jebeno velik vozel. Pred vozlanjem je
-bistveno, da šop zank poravnamo v smer predvidene obremenitve, saj bodo v
-nasprotnem primeru prameni vrvi, in s tem sidriščne točke, obremenjeni neenako.
-Skozi vse zanke v vrhu snopa nazadnje vpnemo [škopec](/skopec) ali drug ustrezen
-kovinski vezni člen. S tem je skupna točka pripravljena na uporabo.
+Z izdelavo jebeno velikega vozla pričnemo tako, da statično vrv najprej prevlečemo skozi vse sidriščne točke ter zvežemo njena konca (alternativno lahko konca pustimo viseti pri strani in ju zvežemo v vozel skupaj z ostalimi prameni). Nato povlečemo vsako povezavo med sosednjima sidriščnima točka, da nastane zanka, in nastale zanke združimo v skupni točki. Pridružimo še zanko, ki povezuje prvo sidriščno točko z zadnjo. Šop zank dobro potresemo, da porazdelimo vrv med pramene, nato pa ga zavežemo v jebeno velik vozel. Pred vozlanjem je bistveno, da šop zank poravnamo v smer predvidene obremenitve, saj bodo v nasprotnem primeru prameni vrvi, in s tem sidriščne točke, obremenjeni neenako. Skozi vse zanke v vrhu snopa nazadnje vpnemo [škopec](skopec) ali drug ustrezen kovinski vezni člen. S tem je skupna točka pripravljena na uporabo.

--- a/src/wiki/kavbojski-vozel.md
+++ b/src/wiki/kavbojski-vozel.md
@@ -1,13 +1,5 @@
 # Kavbojski vozel
 
-_Kavbojski vozel_ je vozel, s katerim zanko (na primer [tovorno](/tovorna-zanka)
-ali [plezalsko](/neskoncna-zanka) zanko) privežemo okoli predmeta. Napravimo ga
-tako, da zanko najprej ovijemo okoli predmeta, nato pa en konec zanke prevlečemo
-skozi drugega. S tem se zanka zadrgne in oprime predmeta, eden od njenih koncev
-pa ostane prost. Kavbojski vozel pogosto uporabljamo za privezovanje
-[tovorne zanke](/tovorna-zanka) okoli drevesa. Še posebej prav pride v tem
-primeru lastnost vozla, da se že praktično neobremenjen dobro oprime drevesa in
-prepreči zanki, da bi zdrsnila na tla. Kavbojski vozel s pridom izkoriščamo tudi
-za povezovanje več zaporednih zank v daljši niz.
+_Kavbojski vozel_ je vozel, s katerim zanko (na primer [tovorno](tovorna-zanka) ali [plezalsko](neskoncna-zanka) zanko) privežemo okoli predmeta. Napravimo ga tako, da zanko najprej ovijemo okoli predmeta, nato pa en konec zanke prevlečemo skozi drugega. S tem se zanka zadrgne in oprime predmeta, eden od njenih koncev pa ostane prost. Kavbojski vozel pogosto uporabljamo za privezovanje [tovorne zanke](tovorna-zanka) okoli drevesa. Še posebej prav pride v tem primeru lastnost vozla, da se že praktično neobremenjen dobro oprime drevesa in prepreči zanki, da bi zdrsnila na tla. Kavbojski vozel s pridom izkoriščamo tudi za povezovanje več zaporednih zank v daljši niz.
 
 [Kavbojski vozel v alpiročniku](https://alpirocnik.rasica.org/wiki/Vrvi,_vozli_in_njihova_uporaba#Kavbojski_vozel)

--- a/src/wiki/macek.md
+++ b/src/wiki/macek.md
@@ -1,18 +1,9 @@
 # Maček
 
-_Maček_ je vponka, ki ima na vrhu vgrajen prosto vrteč se valj. V visokovanju
-ima dve glavni uporabi, in sicer kot sredstvo za prevažanje po
-[visokici](/visokica) ter kot večnamenski [škripec](/skripec) za [trak](/trak).
-V slednji vlogi ga v kombinaciji z [banano](/banana) in [primežem](/primez)
-pogosto izkoriščamo pri [napenjanju](/napenjanje).
+_Maček_ je vponka, ki ima na vrhu vgrajen prosto vrteč se valj. V visokovanju ima dve glavni uporabi, in sicer kot sredstvo za prevažanje po [visokici](visokica) ter kot večnamenski [škripec](skripec) za [trak](trak). V slednji vlogi ga v kombinaciji z [banano](banana) in [primežem](primez) pogosto izkoriščamo pri [napenjanju](napenjanje).
 
 ![Maček z matico](images/hangover.jpg)
 
-Zaradi nekoliko smešnega imena tega pripomočka velja pristaviti besedo ali dve o
-izvoru slovenskega izraza. Prvi potrošniško dostopni izdelek tega tipa je nosil
-tržno ime HangOver. Ker gre že pri izvornem izrazu za besedno igro, smo
-slovenski visokovalci šalo peljali dalje in HangOver prevedli kot _maček_ (tj.
-alkoholni maček). Izbiro je nato le še utrdila ugotovitev, da vsebujejo tovorni
-žerjavi podoben sestavni del, ki se prav zares imenuje - maček.
+Zaradi nekoliko smešnega imena tega pripomočka velja pristaviti besedo ali dve o izvoru slovenskega izraza. Prvi potrošniško dostopni izdelek tega tipa je nosil tržno ime HangOver. Ker gre že pri izvornem izrazu za besedno igro, smo slovenski visokovalci šalo peljali dalje in HangOver prevedli kot _maček_ (tj. alkoholni maček). Izbiro je nato le še utrdila ugotovitev, da vsebujejo tovorni žerjavi podoben sestavni del, ki se prav zares imenuje – maček.
 
 ![Lara s svojimi mački](images/lararolex.jpg)

--- a/src/wiki/mehanska-prednost.md
+++ b/src/wiki/mehanska-prednost.md
@@ -1,13 +1,5 @@
 # Mehanska prednost
 
-_Mehanska prednost_ je pomnožitev sile, ki jo dosežemo s preusmerjanjem vrvi ali
-[traku](/trak), običajno preko [škripcev](/skripec). Mehanska prednost nam
-omogoča, da na eni strani sistema dosežemo večjo silo in manjši pomik, na drugi
-strani sistema pa manjšo silo in večji pomik. Princip s pridom izkoriščamo v
-[napenjalnih sistemih](/napenjalni-sistem).
+_Mehanska prednost_ je pomnožitev sile, ki jo dosežemo s preusmerjanjem vrvi ali [traku](trak), običajno preko [škripcev](skripec). Mehanska prednost nam omogoča, da na eni strani sistema dosežemo večjo silo in manjši pomik, na drugi strani sistema pa manjšo silo in večji pomik. Princip s pridom izkoriščamo v [napenjalnih sistemih](napenjalni-sistem).
 
-Mehansko prednost opredelimo z razmerjem: če imamo, na primer, škripčevje z
-mehansko prednostjo 5:1, to pomeni, da bomo z vlečenjem prostega konca vrvi s
-silo 1 kN ustvarili silo 5 kN na drugem koncu škripčevja. Razmerje pomikov pa je
-ravno obratno: za pomik škripčevja za 1 m na mestu, kjer je sila večja, bomo
-morali iz sistema povleči 5 m vrvi na koncu, na katerem je sila manjša.
+Mehansko prednost opredelimo z razmerjem: če imamo, na primer, škripčevje z mehansko prednostjo 5:1, to pomeni, da bomo z vlečenjem prostega konca vrvi s silo 1 kN ustvarili silo 5 kN na drugem koncu škripčevja. Razmerje pomikov pa je ravno obratno: za pomik škripčevja za 1 m na mestu, kjer je sila večja, bomo morali iz sistema povleči 5 m vrvi na koncu, na katerem je sila manjša.

--- a/src/wiki/minimalna-porusna-sila.md
+++ b/src/wiki/minimalna-porusna-sila.md
@@ -1,20 +1,5 @@
 # Minimalna porušna sila
 
-_Minimalna porušna sila_ (krajšava MBS, angl. _minimum breaking strength_) je
-podatek, ki ga navede proizvajalec opreme, in pove silo, ki je ob enkratni
-obremenitvi potrebna za porušenje izdelka (na primer pretrganje [traku](/trak)
-ali lom [vponke](/vponka)). Podatek običajno pride v spremljavi drugega podatka,
-[največje delovne obremenitve](/najvecja-delovna-obremenitev) (WLL): slednji
-podaja silo, ki je med običajno uporabo ne smemo preseči, če ne želimo
-poslabšati zagotovljenega MBS. Oprema, ki je bila med uporabo izpostavljena
-obremenitvam nad WLL, se lahko poruši pri sili, manjši od MBS. Drugi dejavniki,
-ki lahko povzročijo odpoved pri silah, manjših od MBS, so starost izdelka,
-poškodbe ter nepravilna uporaba.
+_Minimalna porušna sila_ (krajšava MBS, angl. _minimum breaking strength_) je podatek, ki ga navede proizvajalec opreme, in pove silo, ki je ob enkratni obremenitvi potrebna za porušenje izdelka (na primer pretrganje [traku](trak) ali lom [vponke](vponka)). Podatek običajno pride v spremljavi drugega podatka, [največje delovne obremenitve](najvecja-delovna-obremenitev) (WLL): slednji podaja silo, ki je med običajno uporabo ne smemo preseči, če ne želimo poslabšati zagotovljenega MBS. Oprema, ki je bila med uporabo izpostavljena obremenitvam nad WLL, se lahko poruši pri sili, manjši od MBS. Drugi dejavniki, ki lahko povzročijo odpoved pri silah, manjših od MBS, so starost izdelka, poškodbe ter nepravilna uporaba.
 
-Pri oceni tveganj moramo upoštevati, da je karakteristika MBS izmerjena v
-idealnih okoliščinah. Minimalno porušno silo [trakov](/trak) se, na primer, meri
-na napravah, na katerih je trak ovit okoli dveh valjev velikega premera. V
-[banani](/banana) je premer pritrdilnega elementa manjši, zato se lahko trak v
-njej pretrga tudi pod MBS. Porušno silo tekstilnih izdelkov (trakovi, vrvi) še
-zlasti zmanjša uporaba vozlov. Tveganju zaradi teh nedoločenosti se izognemo z
-dovoljšnjim [varnostnim razmerjem](/varnostno-razmerje).
+Pri oceni tveganj moramo upoštevati, da je karakteristika MBS izmerjena v idealnih okoliščinah. Minimalno porušno silo [trakov](trak) se, na primer, meri na napravah, na katerih je trak ovit okoli dveh valjev velikega premera. V [banani](banana) je premer pritrdilnega elementa manjši, zato se lahko trak v njej pretrga tudi pod MBS. Porušno silo tekstilnih izdelkov (trakovi, vrvi) še zlasti zmanjša uporaba vozlov. Tveganju zaradi teh nedoločenosti se izognemo z dovoljšnjim [varnostnim razmerjem](varnostno-razmerje).

--- a/src/wiki/mnozilnik.md
+++ b/src/wiki/mnozilnik.md
@@ -1,21 +1,5 @@
 # Množilnik
 
-_Množilnik_ je komponenta, s katero dosežemo pomnožitev sile na del
-[napenjalnega sistema](/napenjalni-sistem), na katerem je nameščena. Uporabimo
-ga, kadar s samim napenjalnim sistemom ne uspemo doseči dovoljšnje
-[napetosti](/napetost) [traku](/trak). Ime komponente izhaja iz dejstva, da se
-[mehanska prednost](/mehanska-prednost) z dodatkom vsakega množilnika pomnoži.
-Če je, na primer, osnovni napenjalni sistem škripčevje z mehansko prednostjo
-5:1, z dodatkom množilnika 3:1 povečamo skupno mehansko prednost na 15:1, z
-zaporednim dodatkom še enega enakega množilnika pa že na 45:1. Čeprav se to
-sliši zelo praktično, saj z veliko pomnožitvijo lahko en sam človek doseže
-precejšnje sile, imajo množilniki slabo lastnost, da jih je treba po vsakem
-potegu razbremeniti in resetirati - pomakniti naprej po vrvi, na katero
-delujejo. Napenjanje lahko tako postane zelo zamudno. Zato se v praksi pogosto
-najprej poslužimo rešitve, da vrv (ali trak) potegne več ljudi, in šele če to ne
-zadostuje, nameščamo množilnike.
+_Množilnik_ je komponenta, s katero dosežemo pomnožitev sile na del [napenjalnega sistema](napenjalni-sistem), na katerem je nameščena. Uporabimo ga, kadar s samim napenjalnim sistemom ne uspemo doseči dovoljšnje [napetosti](napetost) [traku](trak). Ime komponente izhaja iz dejstva, da se [mehanska prednost](mehanska-prednost) z dodatkom vsakega množilnika pomnoži. Če je, na primer, osnovni napenjalni sistem škripčevje z mehansko prednostjo 5:1, z dodatkom množilnika 3:1 povečamo skupno mehansko prednost na 15:1, z zaporednim dodatkom še enega enakega množilnika pa že na 45:1. Čeprav se to sliši zelo praktično, saj z veliko pomnožitvijo lahko en sam človek doseže precejšnje sile, imajo množilniki slabo lastnost, da jih je treba po vsakem potegu razbremeniti in resetirati – pomakniti naprej po vrvi, na katero delujejo. Napenjanje lahko tako postane zelo zamudno. Zato se v praksi pogosto najprej poslužimo rešitve, da vrv (ali trak) potegne več ljudi, in šele če to ne zadostuje, nameščamo množilnike.
 
-Preprost množilnik lahko izdelamo iz [vponke](/vponka) ali drugega kovinskega
-veznega člena. Zaradi trenja na vponki tak množilnik ni pretirano učinkovit, je
-pa boljši kot nič. Boljše izkoristke dosežemo z uporabo [škripca](/skripec) ali
-[mačka](/macek).
+Preprost množilnik lahko izdelamo iz [vponke](vponka) ali drugega kovinskega veznega člena. Zaradi trenja na vponki tak množilnik ni pretirano učinkovit, je pa boljši kot nič. Boljše izkoristke dosežemo z uporabo [škripca](skripec) ali [mačka](macek).

--- a/src/wiki/najlonski-vozel.md
+++ b/src/wiki/najlonski-vozel.md
@@ -1,8 +1,5 @@
 # Najlonski vozel
 
-_Najlonski vozel_ je vozel, s katerim napravimo fiksno zanko v koncu vrvi. Je
-eden redkih vozlov, ki ga je mogoče preprosto odvezati tudi po tem, ko je bil
-obremenjen. V visokovanju ga največ uporabljamo pri dostopu do sidrišč s spustom
-po vrvi ter za privezovanje rezervnih vrvi in trakov.
+_Najlonski vozel_ je vozel, s katerim napravimo fiksno zanko v koncu vrvi. Je eden redkih vozlov, ki ga je mogoče preprosto odvezati tudi po tem, ko je bil obremenjen. V visokovanju ga največ uporabljamo pri dostopu do sidrišč s spustom po vrvi ter za privezovanje rezervnih vrvi in trakov.
 
 [Najlonski vozel v alpiročniku](https://alpirocnik.rasica.org/wiki/Vrvi,_vozli_in_njihova_uporaba#Najlonski_vozel)

--- a/src/wiki/najvecja-delovna-obremenitev.md
+++ b/src/wiki/najvecja-delovna-obremenitev.md
@@ -1,13 +1,5 @@
 # Največja delovna obremenitev
 
-_Največja delovna obremenitev_ (krajšava WLL, angl. _working load limit_) je
-podatek, ki ga navede proizvajalec opreme, in podaja silo, ki je ob redni
-uporabi opreme ne smemo preseči, če ne želimo dolgoročno poslabšati
-zanesljivosti izdelka. Oprema, ki je bila med uporabo izpostavljena obremenitvam
-nad WLL, se lahko poruši pri sili, manjši od
-[minimalne porušne sile](/minimalna-porusna-sila) (MBS), ki jo navaja
-proizvajalec.
+_Največja delovna obremenitev_ (krajšava WLL, angl. _working load limit_) je podatek, ki ga navede proizvajalec opreme, in podaja silo, ki je ob redni uporabi opreme ne smemo preseči, če ne želimo dolgoročno poslabšati zanesljivosti izdelka. Oprema, ki je bila med uporabo izpostavljena obremenitvam nad WLL, se lahko poruši pri sili, manjši od [minimalne porušne sile](minimalna-porusna-sila) (MBS), ki jo navaja proizvajalec.
 
-V pomanjkanju podatka o WLL lahko slednjega približno ocenimo iz MBS, in sicer
-tako, da MBS delimo z izbranim [varnostnim razmerjem](/varnostno-razmerje).
-Uveljavljen industrijski standard za ta namen je varnostno razmerje 5.
+V pomanjkanju podatka o WLL lahko slednjega približno ocenimo iz MBS, in sicer tako, da MBS delimo z izbranim [varnostnim razmerjem](varnostno-razmerje). Uveljavljen industrijski standard za ta namen je varnostno razmerje 5.

--- a/src/wiki/napenjalna-stran.md
+++ b/src/wiki/napenjalna-stran.md
@@ -1,7 +1,3 @@
 # Napenjalna stran
 
-_Napenjalna stran_ je krajišče visokice, s katerega [trak](/trak)
-[napenjamo](/napenjanje). Na tej strani je trak vpet v [banano](/banana),
-povezano na [sidrišče](/sidrisce). Praviloma je to bolj dostopna od obeh strani
-visokice in tudi tista, na kateri poteka druženje ob visokovanju. Druga stran
-visokice je [statična stran](/staticna-stran).
+_Napenjalna stran_ je krajišče visokice, s katerega [trak](trak) [napenjamo](napenjanje). Na tej strani je trak vpet v [banano](banana), povezano na [sidrišče](sidrisce). Praviloma je to bolj dostopna od obeh strani visokice in tudi tista, na kateri poteka druženje ob visokovanju. Druga stran visokice je [statična stran](staticna-stran).

--- a/src/wiki/napenjalni-sistem.md
+++ b/src/wiki/napenjalni-sistem.md
@@ -1,38 +1,21 @@
 # Napenjalni sistem
 
-_Napenjalni sistem_ je skupek komponent, s katerim [napenjamo](/napenjanje)
-[trak](/trak). Vsem je skupno, da z njimi ustvarimo
-[mehansko prednost](/mehanska-prednost). Poznamo več osnovnih sistemov:
+_Napenjalni sistem_ je skupek komponent, s katerim [napenjamo](napenjanje) [trak](trak). Vsem je skupno, da z njimi ustvarimo [mehansko prednost](mehanska-prednost). Poznamo več osnovnih sistemov:
 
 ## Buckinghamski sistem
 
-Je največkrat uporabljen pri napenjanju visokic. Zanj potrebujemo le malo
-komponent: za osnoven sistem z mehansko prednostjo 3:1 sta potrebna le
-[primež](/primez) in [maček](/macek), kot del napenjalnega sistema pa deluje
-tudi [banana](/banana), ki po koncu napenjanja ostane na svojem mestu. Pri
-večini visokic že samo s takim sistemom dosežemo dovoljšnjo
-[napetost](/napetost) za hojo. Višje sile je moč doseči tako, da trak povleče
-več ljudi; če to ne zadostuje, pa dodajamo [množilnike](/mnozilnik).
+Je največkrat uporabljen pri napenjanju visokic. Zanj potrebujemo le malo komponent: za osnoven sistem z mehansko prednostjo 3:1 sta potrebna le [primež](primez) in [maček](macek), kot del napenjalnega sistema pa deluje tudi [banana](banana), ki po koncu napenjanja ostane na svojem mestu. Pri večini visokic že samo s takim sistemom dosežemo dovoljšnjo [napetost](napetost) za hojo. Višje sile je moč doseči tako, da trak povleče več ljudi; če to ne zadostuje, pa dodajamo [množilnike](mnozilnik).
 
-![Hangover](images/buckingham.jpg)
+![Buckinghamski sistem](images/buckingham.jpg)
 
 ## Primitivni sistem
 
-Je enostaven sistem, največkrat uporabljen pri napenjanju krajših trakov v parku
-(njegova uporaba je smiselna do dolžine približno 30 m). Zanj potrebujemo več
-[vponk](/vponka) in linelocker. Ustvarimo ga tako, da trak za linelockerjem
-peljemo v več ovojih skozi vponki na linelockerju in [sidrišču](/sidrisce), pri
-čemer vsak nov ovoj postavimo pod prejšnjega. S takšnim ovijanjem dosežemo
-pomnožitev sile, hkrati pa ustvarimo zadostno trenje, da trak, ko ga enkrat
-napnemo, ne more popustiti sam od sebe. Tudi tu je za večjo mehansko prednost
-moč dodati množilnike, ki jih izdelamo z dodatnimi vponkami.
+Je enostaven sistem, največkrat uporabljen pri napenjanju krajših trakov v parku (njegova uporaba je smiselna do dolžine približno 30 m). Zanj potrebujemo več [vponk](vponka) in linelocker. Ustvarimo ga tako, da trak za linelockerjem peljemo v več ovojih skozi vponki na linelockerju in [sidrišču](sidrisce), pri čemer vsak nov ovoj postavimo pod prejšnjega. S takšnim ovijanjem dosežemo pomnožitev sile, hkrati pa ustvarimo zadostno trenje, da trak, ko ga enkrat napnemo, ne more popustiti sam od sebe. Tudi tu je za večjo mehansko prednost moč dodati množilnike, ki jih izdelamo z dodatnimi vponkami.
 
 ![Primitivni sistem 5:1 z množilnikom 3:1](images/primitiv.jpg)
 
 ## Škripčevje
 
-Je bolj kompleksen sistem, sestavljen iz več [škripcev](/skripec), vrvi in
-zavore. Uporablja se za napenjanje dolgih linij oziroma linij, ki potrebujejo
-višje [napetosti](/napetost).
+Je bolj kompleksen sistem, sestavljen iz več [škripcev](skripec), vrvi in zavore. Uporablja se za napenjanje dolgih linij oziroma linij, ki potrebujejo višje [napetosti](napetost).
 
 ![Škripec](images/skripec.jpg)

--- a/src/wiki/napenjanje.md
+++ b/src/wiki/napenjanje.md
@@ -1,19 +1,5 @@
 # Napenjanje
 
-_Napenjanje_ je postopek, s katerim [slackline](/slackline) napnemo na
-[želeno silo](/napetost), da ga pripravimo na hojo. Ker so ciljne napetosti
-večine postavitev (z izjemo rodeo slacklinov) večje od sil, ki jih zmoremo
-ustvariti s telesom, je treba za to uporabiti ustrezen
-[napenjalni sistem](/napenjalni-sistem). Slednji je lahko vezan neposredno na
-konec slacklina in po napenjanju ostane v sistemu, lahko pa ga na [trak](/trak)
-pričvrstimo s [primežem](/primez) in ga po napenjanju odstranimo. Slednja metoda
-je tehnično zahtevnejša, a je tudi varnejša (v sistemu ostane manjše število
-elementov) in bolj prilagodljiva - ni omejitve pri dolžini traku, isti
-napenjalni sistem lahko uporabimo na več mestih.
+_Napenjanje_ je postopek, s katerim [slackline](slackline) napnemo na [želeno silo](napetost), da ga pripravimo na hojo. Ker so ciljne napetosti večine postavitev (z izjemo rodeo slacklinov) večje od sil, ki jih zmoremo ustvariti s telesom, je treba za to uporabiti ustrezen [napenjalni sistem](napenjalni-sistem). Slednji je lahko vezan neposredno na konec slacklina in po napenjanju ostane v sistemu, lahko pa ga na [trak](trak) pričvrstimo s [primežem](primez) in ga po napenjanju odstranimo. Slednja metoda je tehnično zahtevnejša, a je tudi varnejša (v sistemu ostane manjše število elementov) in bolj prilagodljiva – ni omejitve pri dolžini traku, isti napenjalni sistem lahko uporabimo na več mestih.
 
-Po končani uporabi moramo napetost na slacklinu popustiti, da ga lahko podremo.
-Popuščanje lahko izvedemo z napenjalnim sistemom, le da postopek poteka v
-obratni smeri kot pri napenjanju. Večina namenskih napenjalnih sistemov vsebuje
-zavoro, s katero si lahko pri tem pomagamo. Preprostejša možnost, zlasti če smo
-napenjalni sistem po napenjanju odstranili, je uporaba
-[popuščalke](/popuscalka).
+Po končani uporabi moramo napetost na slacklinu popustiti, da ga lahko podremo. Popuščanje lahko izvedemo z napenjalnim sistemom, le da postopek poteka v obratni smeri kot pri napenjanju. Večina namenskih napenjalnih sistemov vsebuje zavoro, s katero si lahko pri tem pomagamo. Preprostejša možnost, zlasti če smo napenjalni sistem po napenjanju odstranili, je uporaba [popuščalke](popuscalka).

--- a/src/wiki/napetost.md
+++ b/src/wiki/napetost.md
@@ -1,6 +1,3 @@
 # Napetost
 
-_Napetost_ je lastnost dane postavitve [traku](/trak) in je odvisna od njegovih
-mehanskih lastnosti ter od [raztega](/raztezek), ki ga dosežemo z
-[napenjanjem](/napenjanje). Opredelimo jo s silo v traku, običajno izraženo v
-kilonewtonih (kN). Visokice so običajno napete na 2 do 3 kN.
+_Napetost_ je lastnost dane postavitve [traku](trak) in je odvisna od njegovih mehanskih lastnosti ter od [raztega](raztezek), ki ga dosežemo z [napenjanjem](napenjanje). Opredelimo jo s silo v traku, običajno izraženo v kilonewtonih (kN). Visokice so običajno napete na 2 do 3 kN.

--- a/src/wiki/neskoncna-zanka.md
+++ b/src/wiki/neskoncna-zanka.md
@@ -1,11 +1,3 @@
 # Neskončna zanka
 
-_Neskončna zanka_ je zanka, narejena iz kosa tekstilnega traku, katerega konca
-sta sešita skupaj. Je zelo prilagodljiv povezovalni element z mnogoterimi
-uporabami. Neskončne zanke imajo dve glavni podvrsti: plezalske zanke ter
-[tovorne zanke](/tovorna-zanka). Plezalske zanke so ožje in izdelane bodisi iz
-poliamidnih vlaken (najlon) ali iz
-[UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (Dyneema). V visokovanju jih
-uporabljamo predvsem kot osebno varovalno opremo ali pripomoček pri
-[postavljanju](/postavljanje). [Tovorne zanke](/Tovorna_zanka) so robustnejše in
-pogosto služijo kot glavni nosilni element [sidrišč](/sidrisce).
+_Neskončna zanka_ je zanka, narejena iz kosa tekstilnega traku, katerega konca sta sešita skupaj. Je zelo prilagodljiv povezovalni element z mnogoterimi uporabami. Neskončne zanke imajo dve glavni podvrsti: plezalske zanke ter [tovorne zanke](tovorna-zanka). Plezalske zanke so ožje in izdelane bodisi iz poliamidnih vlaken (najlon) ali iz [UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (Dyneema). V visokovanju jih uporabljamo predvsem kot osebno varovalno opremo ali pripomoček pri [postavljanju](postavljanje). [Tovorne zanke](tovorna-zanka) so robustnejše in pogosto služijo kot glavni nosilni element [sidrišč](sidrisce).

--- a/src/wiki/osmica.md
+++ b/src/wiki/osmica.md
@@ -1,17 +1,8 @@
 # Osmica
 
-_Osmica_ je vozel s široko uporabo. V visokovanju ga uporabljamo pri
-izdelavi sidrišč ter za privezovanje na [vis](/vis). Prednost
-vozla je, da ga je razmeroma enostavno zavezati ter pregledati, ne more
-se prevreči in tudi ne sam od sebe razvezati.
+_Osmica_ je vozel s široko uporabo. V visokovanju ga uporabljamo pri izdelavi sidrišč ter za privezovanje na [vis](vis). Prednost vozla je, da ga je razmeroma enostavno zavezati ter pregledati, ne more se prevreči in tudi ne sam od sebe razvezati.
 
-Za privezovanje na [vis](/vis) uporabljamo vpleteno različico:
-na neprivezanem visu naredimo osmico, prosti konec visa prevlečemo skozi
-obe glavni zanki na pasu, nato pa z njim sledimo nazaj po poprej
-zavezani osmici. Ko zaključimo, mora biti vozel sestavljen iz petih
-parov vzporednih pramenov vrvi. Osmica ne potrebuje varovalnega vozla,
-ga pa včasih vseeno zavežemo, da porabimo preostanek visa, ki bi sicer
-pri padcih opletal naokoli.
+Za privezovanje na [vis](vis) uporabljamo vpleteno različico: na neprivezanem visu naredimo osmico, prosti konec visa prevlečemo skozi obe glavni zanki na pasu, nato pa z njim sledimo nazaj po poprej zavezani osmici. Ko zaključimo, mora biti vozel sestavljen iz petih parov vzporednih pramenov vrvi. Osmica ne potrebuje varovalnega vozla, ga pa včasih vseeno zavežemo, da porabimo preostanek visa, ki bi sicer pri padcih opletal naokoli.
 
 [Osmica v alpiročniku](https://alpirocnik.rasica.org/wiki/Vrvi,_vozli_in_njihova_uporaba#Osmica.C2.A0)
 

--- a/src/wiki/ovalni-clen.md
+++ b/src/wiki/ovalni-clen.md
@@ -1,13 +1,5 @@
 # Ovalni člen
 
-_Ovalni člen_ je kovinski vezni člen, po obliki podoben členu verige, na katerem
-se ena od stranic zapira z matico. Najpogosteje ga uporabljamo pri izdelavi
-skalnih [sidrišč](/sidrisce), kjer služi kot vezni člen med ušesom skalnega
-vijaka ter statično vrvjo, speljano v [skupno točko](/skupna-tocka). Svoje mesto
-najde tudi v nekaterih različicah [segmentiranja](/segmentiranje).
+_Ovalni člen_ je kovinski vezni člen, po obliki podoben členu verige, na katerem se ena od stranic zapira z matico. Najpogosteje ga uporabljamo pri izdelavi skalnih [sidrišč](sidrisce), kjer služi kot vezni člen med ušesom skalnega vijaka ter statično vrvjo, speljano v [skupno točko](skupna-tocka). Svoje mesto najde tudi v nekaterih različicah [segmentiranja](segmentiranje).
 
-Pred obremenitvijo je treba na členu vedno priviti matico. Odprt člen ima mnogo
-manjšo nosilnost od zaprtega, zato ob obremenitvi odprtega lahko pride do
-deformacije ali celo popolne odpovedi. Prav tako pomembno je, da matico
-zategnemo s ključem, saj privijanje samo z roko pogosto ni dovolj in se matica
-ob vibracijah sčasoma lahko sama odvije.
+Pred obremenitvijo je treba na členu vedno priviti matico. Odprt člen ima mnogo manjšo nosilnost od zaprtega, zato ob obremenitvi odprtega lahko pride do deformacije ali celo popolne odpovedi. Prav tako pomembno je, da matico zategnemo s ključem, saj privijanje samo z roko pogosto ni dovolj in se matica ob vibracijah sčasoma lahko sama odvije.

--- a/src/wiki/pilotna-vrv.md
+++ b/src/wiki/pilotna-vrv.md
@@ -1,23 +1,8 @@
 # Pilotna vrv
 
-_Pilotna vrv_ (včasih skrajšano tudi samo _pilotka_) je vrvica, s katero pri
-postavljanju [visokice](/visokica) povlečemo trakova preko vrzeli. Navadno za
-pilotno vrv uporabljamo vrv debeline 3 ali 4 mm. Štirimilimetrska vrv je še
-zlasti priročna zato, ker je združljiva s prižemami ter drugimi napravami z
-zobci (na primer škripec Micro Traxion).
+_Pilotna vrv_ (včasih skrajšano tudi samo _pilotka_) je vrvica, s katero pri postavljanju [visokice](visokica) povlečemo trakova preko vrzeli. Navadno za pilotno vrv uporabljamo vrv debeline 3 ali 4 mm. Štirimilimetrska vrv je še zlasti priročna zato, ker je združljiva s prižemami ter drugimi napravami z zobci (na primer škripec Micro Traxion).
 
-Pri [postavljanju](/postavljanje) moramo konec pilotne vrvi najprej spraviti na
-oddaljeno krajišče. Pri krajših relacijah to storimo tako, da na vrv privežemo
-utež, ki jo nato zalučamo preko vrzeli. Če vrzel ni pregloboka in imamo preprost
-dostop do njenega dna, je smiselna metoda tudi to, da z vsake strani v globino
-vržemo po eno vrvico in nato spodaj njuna konca spojimo z vozlom. Pri večjih
-razdaljah pilotno vrv vzpostavimo v dveh stopnjah: preko vrzeli najprej spravimo
-tanjšo vrvico ali laks, nanj pa nato privežemo pilotno vrv in jo prevlečemo na
-drugo stran. Daljše razdalje zahtevajo tudi več napora in iznajdljivosti, da
-tanko vrvico ali laks v prvi stopnji sploh spravimo na drugo stran. Pri tem se
-poslužujemo pripomočkov, kot so frače, prače, ribiške palice ali loki, za zares
-dolge razdalje pa je najučinkovitejši prenos z dronom - če nam je ta možnost le
-na voljo.
+Pri [postavljanju](postavljanje) moramo konec pilotne vrvi najprej spraviti na oddaljeno krajišče. Pri krajših relacijah to storimo tako, da na vrv privežemo utež, ki jo nato zalučamo preko vrzeli. Če vrzel ni pregloboka in imamo preprost dostop do njenega dna, je smiselna metoda tudi to, da z vsake strani v globino vržemo po eno vrvico in nato spodaj njuna konca spojimo z vozlom. Pri večjih razdaljah pilotno vrv vzpostavimo v dveh stopnjah: preko vrzeli najprej spravimo tanjšo vrvico ali laks, nanj pa nato privežemo pilotno vrv in jo prevlečemo na drugo stran. Daljše razdalje zahtevajo tudi več napora in iznajdljivosti, da tanko vrvico ali laks v prvi stopnji sploh spravimo na drugo stran. Pri tem se poslužujemo pripomočkov, kot so frače, prače, ribiške palice ali loki, za zares dolge razdalje pa je najučinkovitejši prenos z dronom – če nam je ta možnost le na voljo.
 
 ![100 m 4-milimetrske vrvice v priročni torbici](images/tagline.jpg)
 ![200 m 3-milimetrske vrvice z utežjo za metanje](images/tagline-weight.jpg)

--- a/src/wiki/podloga.md
+++ b/src/wiki/podloga.md
@@ -1,17 +1,5 @@
 # Podloga
 
-_Podloga_ so predmeti, s katerimi zaščitimo komponente sistema pred
-[abrazijo](/abrazija). [Zanke](/Neskončna_zanka) in vrvi obvarujemo pred
-drgnjenjem ob skale tako, da mesto drgnjenja podložimo z debelim kosom filca ali
-drugega blaga. V ta namen dobro služijo tudi razrezane odslužene gasilske cevi.
-Za podlaganje lahko uporabimo opremo, ki je trenutno ne potrebujemo, na primer
-zloženo vrečo, v kateri smo prinesli komponente za postavljanje
-[sidrišča](/sidrisce). V primeru ostrih skalnih robov na krajišču
-[visokice](/visokica) njuna [trakova](/trak) zaščitimo z blazinami, nahrbtniki,
-ležalnimi podlogami ali kar na kup zmetanim neporabljenim preostankom trakov. Še
-bolje je, če poleg tega [skupno točko](/skupna-tocka) sidrišča odmaknemo od tal
-z [A-okvirjem](/A-okvir). V vseh primerih moramo zagotoviti, da se podloga ne bo
-sčasoma premaknila z mesta. Če je potrebno, jo pričvrstimo z vrvicami ali
-lepilnim trakom.
+_Podloga_ so predmeti, s katerimi zaščitimo komponente sistema pred [abrazijo](abrazija). [Zanke](neskoncna-zanka) in vrvi obvarujemo pred drgnjenjem ob skale tako, da mesto drgnjenja podložimo z debelim kosom filca ali drugega blaga. V ta namen dobro služijo tudi razrezane odslužene gasilske cevi. Za podlaganje lahko uporabimo opremo, ki je trenutno ne potrebujemo, na primer zloženo vrečo, v kateri smo prinesli komponente za postavljanje [sidrišča](sidrisce). V primeru ostrih skalnih robov na krajišču [visokice](visokica) njuna [trakova](trak) zaščitimo z blazinami, nahrbtniki, ležalnimi podlogami ali kar na kup zmetanim neporabljenim preostankom trakov. Še bolje je, če poleg tega [skupno točko](skupna-tocka) sidrišča odmaknemo od tal z [A-okvirjem](a-okvir). V vseh primerih moramo zagotoviti, da se podloga ne bo sčasoma premaknila z mesta. Če je potrebno, jo pričvrstimo z vrvicami ali lepilnim trakom.
 
 ![Zaščita](images/zascita.jpg)

--- a/src/wiki/podlozka.md
+++ b/src/wiki/podlozka.md
@@ -1,15 +1,5 @@
 # Podložka
 
-_Podložka_ je krajši košček [traku](/trak), običajno dolžine okoli 10 cm, ki
-služi za ojačitev oziroma boljše ohranjanje nosilnosti
-[šivane zanke](/sivana-zanka) pri uporabi le-te z
-[vrvnim škopcem](/vrvni-skopec). Vsak dovolj dolg in debel košček traku lahko
-uporabimo za podložko tako, da ga prepognemo in vstavimo v konec šivane zanke.
-Na trgu so na voljo tudi namenske podložke, izdelane iz traku, prepognjenega in
-zašitega v obliko kaplje.
+_Podložka_ je krajši košček [traku](trak), običajno dolžine okoli 10 cm, ki služi za ojačitev oziroma boljše ohranjanje nosilnosti [šivane zanke](sivana-zanka) pri uporabi le-te z [vrvnim škopcem](vrvni-skopec). Vsak dovolj dolg in debel košček traku lahko uporabimo za podložko tako, da ga prepognemo in vstavimo v konec šivane zanke. Na trgu so na voljo tudi namenske podložke, izdelane iz traku, prepognjenega in zašitega v obliko kaplje.
 
-[Vrvni škopci](/vrvni-skopec) imajo v primerjavi s kovinskimi [škopci](/skopec)
-to slabo lastnost, da pri obremenitvi stisnejo in s tem deformirajo trak v
-šivani zanki. Zaradi neenakomerne obremenitve traku v šivani zanki ta izgubi
-nekaj svoje nosilnosti. Podložka zanko utrdi, s tem zmanjša deformacijo ter
-nosilnost povrne na skoraj polno vrednost.
+[Vrvni škopci](vrvni-skopec) imajo v primerjavi s kovinskimi [škopci](skopec) to slabo lastnost, da pri obremenitvi stisnejo in s tem deformirajo trak v šivani zanki. Zaradi neenakomerne obremenitve traku v šivani zanki ta izgubi nekaj svoje nosilnosti. Podložka zanko utrdi, s tem zmanjša deformacijo ter nosilnost povrne na skoraj polno vrednost.

--- a/src/wiki/pomozni-trak.md
+++ b/src/wiki/pomozni-trak.md
@@ -1,72 +1,23 @@
 # Pomožni trak
 
-_Pomožni trak_ je eden od dveh [trakov](/trak), ki sestavljata
-[visokico](/visokica), in je v veliki meri zaslužen za njen značilni videz.
-Pomožni trak ni napet, temveč je v zankah obešen pod
-[glavnim trakom](/glavni-trak). Njegova primarna vloga je zagotavljanje
-[redundance](/redundanca): če bi iz kakršnegakoli vzroka glavni trak odpovedal,
-bi nosilno vlogo prevzel pomožni trak in s tem preprečil padec visokovalca v
-globino. Sekundarna vloga pomožnega traku je očem bolj skrita, a kljub temu še
-kako pomembna. Njegove zanke namreč dušijo tresljaje glavnega traku ter s tem
-močno olajšajo hojo. Takšno dušenje je še zlasti pomembno pri dolgih trakovih,
-ki bi jih bilo brez pomožnega traku praktično nemogoče prehoditi.
+_Pomožni trak_ je eden od dveh [trakov](trak), ki sestavljata [visokico](visokica), in je v veliki meri zaslužen za njen značilni videz. Pomožni trak ni napet, temveč je v zankah obešen pod [glavnim trakom](glavni-trak). Njegova primarna vloga je zagotavljanje [redundance](redundanca): če bi iz kakršnegakoli vzroka glavni trak odpovedal, bi nosilno vlogo prevzel pomožni trak in s tem preprečil padec visokovalca v globino. Sekundarna vloga pomožnega traku je očem bolj skrita, a kljub temu še kako pomembna. Njegove zanke namreč dušijo tresljaje glavnega traku ter s tem močno olajšajo hojo. Takšno dušenje je še zlasti pomembno pri dolgih trakovih, ki bi jih bilo brez pomožnega traku praktično nemogoče prehoditi.
 
 ## Izbira in razmislek o varnosti
 
-Zaradi njegove pomembne varnostne vloge je treba pomožni trak pazljivo izbrati
-in temeljito premisliti njegovo postavitev. V primeru odpovedi glavnega traku
-pomožni trak teže visokovalca ne prevzame takoj, zato najprej sledi vsaj nekaj
-metrov padca, ki ga mora pomožni trak - ko se naposled napne - primerno
-ublažiti. S tega vidika je za pomožni trak bolje uporabiti trak z večjim
-[raztezkom](/raztezek), saj so v tem primeru telo visokovalca ter komponente
-sistema izpostavljene manjšim silam. Pri tem igra vlogo tudi dolžina pomožnega
-traku - večja ko je, globlji je padec in večje so sile. V primeru nižjih visokic
-je treba prevprašati tudi možnost, da bi na dnu takega padca visokovalec že
-zadel tla.
+Zaradi njegove pomembne varnostne vloge je treba pomožni trak pazljivo izbrati in temeljito premisliti njegovo postavitev. V primeru odpovedi glavnega traku pomožni trak teže visokovalca ne prevzame takoj, zato najprej sledi vsaj nekaj metrov padca, ki ga mora pomožni trak – ko se naposled napne – primerno ublažiti. S tega vidika je za pomožni trak bolje uporabiti trak z večjim [raztezkom](raztezek), saj so v tem primeru telo visokovalca ter komponente sistema izpostavljene manjšim silam. Pri tem igra vlogo tudi dolžina pomožnega traku – večja ko je, globlji je padec in večje so sile. V primeru nižjih visokic je treba prevprašati tudi možnost, da bi na dnu takega padca visokovalec že zadel tla.
 
-Kljub temu, da je krajši pomožni trak varnejši, s krajšanjem vseeno ne gre
-pretiravati, saj se s prekratkim pomožnim trakom odrečemo njegovi
-stabilizacijski vlogi. Čista skrajnost, ko je pomožni trak stisnjen ob glavnega,
-ni priporočljiva tudi zato, ker lahko isti neljubi dejavnik poškoduje oba
-hkrati.
+Kljub temu, da je krajši pomožni trak varnejši, s krajšanjem vseeno ne gre pretiravati, saj se s prekratkim pomožnim trakom odrečemo njegovi stabilizacijski vlogi. Čista skrajnost, ko je pomožni trak stisnjen ob glavnega, ni priporočljiva tudi zato, ker lahko isti neljubi dejavnik poškoduje oba hkrati.
 
-Ker je vse omenjene vidike težko pretehtati "na oko", je na spletni strani
-Mednarodne slacklinerske zveze (ISA) na voljo
-[spletna aplikacija](https://data.slacklineinternational.org/safety/warnings/backup-fall/),
-s katero je mogoče preračunati povese, sile in druge količine, povezane s padcem
-na pomožni trak.
+Ker je vse omenjene vidike težko pretehtati "na oko", je na spletni strani Mednarodne slacklinerske zveze (ISA) na voljo [spletna aplikacija](https://data.slacklineinternational.org/safety/warnings/backup-fall/), s katero je mogoče preračunati povese, sile in druge količine, povezane s padcem na pomožni trak.
 
 ## Zanke
 
-Pred [postavljanjem](/postavljanje) visokice je treba pomožni trak pripeti na
-glavnega, da se ustvarijo zanke. To storimo s kosi lepilnega traku, ki jih
-prilepimo tako, da se enega od trakov oprimejo, drugi pa lahko prosto drsi
-skoznje. Pri tem moramo biti pozorni, da so razdalje med lepilnimi trakovi čim
-bolj raznolike, saj le tako primerno dušijo tresljaje glavnega traku. Če so si
-zanke po velikosti preveč podobne, dosežemo namreč prav nasproten učinek - na
-napeti visokici zanihajo vse obenem in lovljenje ravnotežja postane težje.
-Tipične dolžine zank se gibljejo v območju med dvema in petimi metri,
-porazdeliti pa jih poskusimo čim bolj naključno.
+Pred [postavljanjem](postavljanje) visokice je treba pomožni trak pripeti na glavnega, da se ustvarijo zanke. To storimo s kosi lepilnega traku, ki jih prilepimo tako, da se enega od trakov oprimejo, drugi pa lahko prosto drsi skoznje. Pri tem moramo biti pozorni, da so razdalje med lepilnimi trakovi čim bolj raznolike, saj le tako primerno dušijo tresljaje glavnega traku. Če so si zanke po velikosti preveč podobne, dosežemo namreč prav nasproten učinek – na napeti visokici zanihajo vse obenem in lovljenje ravnotežja postane težje. Tipične dolžine zank se gibljejo v območju med dvema in petimi metri, porazdeliti pa jih poskusimo čim bolj naključno.
 
 ## Nameščanje
 
-Na [napenjalni strani](/napenjalna-stran) pomožni trak vpnemo v banano, če le
-imamo na razpolago dovolj opreme za to. Alternativna, a manj priporočljiva
-možnost je, da trak zavežemo v [Frostov vozel](/frostov-vozel) in vpnemo v
-[škopec](/skopec). Na statični strani za vpenjanje izkoristimo
-[šivano zanko](/sivana-zanka), če je ta na voljo. Dolžino pomožnega traku
-odmerimo tako, da ta ob padcu na [vis](/vis) ravno še ne prevzame nobene sile.
-Če med visokovanjem ugotovimo, da je pomožni trak predolg ali prekratek, njegovo
-dolžino prilagodimo, a seveda _ne_ medtem, ko je na traku človek.
+Na [napenjalni strani](napenjalna-stran) pomožni trak vpnemo v banano, če le imamo na razpolago dovolj opreme za to. Alternativna, a manj priporočljiva možnost je, da trak zavežemo v [Frostov vozel](frostov-vozel) in vpnemo v [škopec](skopec). Na statični strani za vpenjanje izkoristimo [šivano zanko](sivana-zanka), če je ta na voljo. Dolžino pomožnega traku odmerimo tako, da ta ob padcu na [vis](vis) ravno še ne prevzame nobene sile. Če med visokovanjem ugotovimo, da je pomožni trak predolg ali prekratek, njegovo dolžino prilagodimo, a seveda _ne_ medtem, ko je na traku človek.
 
 ## Rokovanje
 
-Pri padcih se pomožni trak pogosto zamota preko glavnega in povzroči zavoje v
-njem. Zmešnjavo lahko do neke mere popravimo tako, da odločno, a ne sunkovito,
-potegnemo zanj. Dostikrat se s tem trak vsaj deloma odvije, vendar lahko manever
-na daljših visokicah pusti neprijetno posledico: pomožni trak se nabere v
-velikih zankah na eni strani visokice, na drugi pa zank praktično ni več. Hoja
-na bližnji strani postane težka, ker zanke preveč nihajo, na drugi strani pa še
-težja, ker pomožni trak ne opravlja stabilizacijske vloge. Zato je pravzaprav
-najbolje, da se zamotanemu pomožnemu traku sploh ne pustimo motiti in se
-preprosto navadimo hoditi po njem.
+Pri padcih se pomožni trak pogosto zamota preko glavnega in povzroči zavoje v njem. Zmešnjavo lahko do neke mere popravimo tako, da odločno, a ne sunkovito, potegnemo zanj. Dostikrat se s tem trak vsaj deloma odvije, vendar lahko manever na daljših visokicah pusti neprijetno posledico: pomožni trak se nabere v velikih zankah na eni strani visokice, na drugi pa zank praktično ni več. Hoja na bližnji strani postane težka, ker zanke preveč nihajo, na drugi strani pa še težja, ker pomožni trak ne opravlja stabilizacijske vloge. Zato je pravzaprav najbolje, da se zamotanemu pomožnemu traku sploh ne pustimo motiti in se preprosto navadimo hoditi po njem.

--- a/src/wiki/popuscalka.md
+++ b/src/wiki/popuscalka.md
@@ -1,26 +1,9 @@
 # Popuščalka
 
-_Popuščalka_ je pripomoček, s katerim nadzorovano popustimo
-[napetost](/napetost) na [slacklinu](/slackline), da ga lahko podremo. Uporablja
-se v primerih, ko [napenjalni sistem](/napenjalni-sistem) ni del slacklina. To
-je na [visokicah](/visokica) zelo pogost pristop, saj z manjšim številom
-komponent sistema zmanjšamo tudi stopnjo tveganja. Popuščalka je praviloma
-nameščena na [statični strani](/staticna-stran) visokice.
+_Popuščalka_ je pripomoček, s katerim nadzorovano popustimo [napetost](napetost) na [slacklinu](slackline), da ga lahko podremo. Uporablja se v primerih, ko [napenjalni sistem](napenjalni-sistem) ni del slacklina. To je na [visokicah](visokica) zelo pogost pristop, saj z manjšim številom komponent sistema zmanjšamo tudi stopnjo tveganja. Popuščalka je praviloma nameščena na [statični strani](staticna-stran) visokice.
 
-Popuščalka je sestavljena iz dveh kovinskih osi, preko katerih je ovitih več
-ovojev [traku](/trak). Na eno od osi je trak vpet s
-[šivano zanko](/sivana-zanka). Priporočljivo je napraviti vsaj šest ovojev,
-pogosto pa uporabimo še kakega več. Preostanek traku trdno privežemo okoli
-ovojev, na primer z bičevim vozlom. Za dobro mero konec traku še zavozlamo, s
-čimer preprečimo, da bi zaradi tresljajev ob uporabi zdrsel skozi bičev vozel.
+Popuščalka je sestavljena iz dveh kovinskih osi, preko katerih je ovitih več ovojev [traku](trak). Na eno od osi je trak vpet s [šivano zanko](sivana-zanka). Priporočljivo je napraviti vsaj šest ovojev, pogosto pa uporabimo še kakega več. Preostanek traku trdno privežemo okoli ovojev, na primer z bičevim vozlom. Za dobro mero konec traku še zavozlamo, s čimer preprečimo, da bi zaradi tresljajev ob uporabi zdrsel skozi bičev vozel.
 
-Za osi popuščalke se navadno izkorišča kar vijaka dveh nasproti si postavljenih
-[škopcev](/skopec). Pri tem je treba paziti na orientacijo škopcev: trak mora
-pri odvijanju drseti tako, da vijakov ne more odviti, temveč jih lahko le bolj
-privije. Za eno od osi popuščalke je mogoče uporabiti tudi os na zadnji strani
-[banane](/banana), če je ta primerno oblikovana.
+Za osi popuščalke se navadno izkorišča kar vijaka dveh nasproti si postavljenih [škopcev](skopec). Pri tem je treba paziti na orientacijo škopcev: trak mora pri odvijanju drseti tako, da vijakov ne more odviti, temveč jih lahko le bolj privije. Za eno od osi popuščalke je mogoče uporabiti tudi os na zadnji strani [banane](banana), če je ta primerno oblikovana.
 
-Ko želimo popustiti napetost, konec traku popuščalke odvežemo, po potrebi
-odvijemo kak ovoj (če je trenje preveliko), nato pa z roko nadzorujemo hitrost
-popuščanja. Pomembno je, da pri tem ves čas držimo konec traku, da nam ta ne
-zbeži iz rok.
+Ko želimo popustiti napetost, konec traku popuščalke odvežemo, po potrebi odvijemo kak ovoj (če je trenje preveliko), nato pa z roko nadzorujemo hitrost popuščanja. Pomembno je, da pri tem ves čas držimo konec traku, da nam ta ne zbeži iz rok.

--- a/src/wiki/postavljanje.md
+++ b/src/wiki/postavljanje.md
@@ -1,10 +1,5 @@
 # Postavljanje
 
-_Postavljanje_ je velik del visokovanja. Radi rečemo, da nam vzame kar tretjino
-vsega časa preživetega pri visokovanju. Je mučno in odgovorno delo, ki ga
-ponavadi opravljajo izkušeni visokovalci, kar pa ne pomeni, da tudi začetniki ne
-smejo sodelovati. Prav nasprotno, za uspešno visokovanje morajo biti v ta del
-vključeni vsi sodelujoči. Med "postavljanje" spadajo tudi dejavnosti kot so:
-pospravljanje, prenašanje opreme, zlaganje vrvi in pilotk, tejpanje, itd.
+_Postavljanje_ je velik del visokovanja. Radi rečemo, da nam vzame kar tretjino vsega časa preživetega pri visokovanju. Je mučno in odgovorno delo, ki ga ponavadi opravljajo izkušeni visokovalci, kar pa ne pomeni, da tudi začetniki ne smejo sodelovati. Prav nasprotno, za uspešno visokovanje morajo biti v ta del vključeni vsi sodelujoči. Med "postavljanje" spadajo tudi dejavnosti kot so: pospravljanje, prenašanje opreme, zlaganje vrvi in pilotk, tejpanje, itd.
 
 _Samo z udejstvovanjem tudi pri postavljanju postaneš visokovalec!_

--- a/src/wiki/primez.md
+++ b/src/wiki/primez.md
@@ -1,46 +1,19 @@
 # Primež
 
-_Primež_ je naprava, ki trdno zgrabi [trak](/trak) in se uporablja za
-[napenjanje](/napenjanje) [slacklinov](/slackline). Najpomembnejša lastnost
-primeža je, da ga lahko namestimo na že napet trak in ga, ko silo nanj
-popustimo, s traku tudi preprosto odstranimo. Čeprav na videz opravlja podobno
-vlogo kot [banana](/banana), ima primež precej drugačne lastnosti in namen, zato
-ni ustrezno nadomestilo zanjo.
+_Primež_ je naprava, ki trdno zgrabi [trak](trak) in se uporablja za [napenjanje](napenjanje) [slacklinov](slackline). Najpomembnejša lastnost primeža je, da ga lahko namestimo na že napet trak in ga, ko silo nanj popustimo, s traku tudi preprosto odstranimo. Čeprav na videz opravlja podobno vlogo kot [banana](banana), ima primež precej drugačne lastnosti in namen, zato ni ustrezno nadomestilo zanjo.
 
 ## Princip delovanja
 
-Osnova primeža sta dve vzporedni kovinski plošči, katerih stični ploskvi sta
-prevlečeni z gumo. Pri nameščanju primeža plošči razklenemo, z njima obdamo
-trak, nato pa namestimo nazaj ogrodje oziroma mehanizem primeža. Ko primež
-izpostavimo sili vzdolž traku, se plošči stisneta in zgrabita trak. Ko sila
-popusti, je mogoče plošči zopet razkleniti in primež odstraniti.
+Osnova primeža sta dve vzporedni kovinski plošči, katerih stični ploskvi sta prevlečeni z gumo. Pri nameščanju primeža plošči razklenemo, z njima obdamo trak, nato pa namestimo nazaj ogrodje oziroma mehanizem primeža. Ko primež izpostavimo sili vzdolž traku, se plošči stisneta in zgrabita trak. Ko sila popusti, je mogoče plošči zopet razkleniti in primež odstraniti.
 
 ## Uporaba
 
-Pri napenjanju traku primež namestimo pred [banano](/banana) in nanj pripnemo
-[napenjalni sistem](/napenjalni-sistem). Primež potisnemo kolikor je mogoče
-naprej po traku, nato pa pričnemo z napenjanjem. Pri uporabi vrvnih
-[škripcev](/skripec) se trak med primežem in banano sprosti in ga moramo sproti
-ročno vleči v banano. To ni potrebno, če je banana sama del napenjalnega sistema
-(na primer v kombinaciji z [mačkom](/macek)). Ko nam zmanjka hoda v napenjalnem
-sistemu ali ko pride primež preblizu banane, silo v napenjalnem sistemu
-popustimo in primež ponovno premaknemo naprej po traku. Postopek ponavljamo do
-želene [napetosti](/napetost), nato pa primež odstranimo. Dokler je primež
-nameščen na trak, po njem ne smemo hoditi!
+Pri napenjanju traku primež namestimo pred [banano](banana) in nanj pripnemo [napenjalni sistem](napenjalni-sistem). Primež potisnemo kolikor je mogoče naprej po traku, nato pa pričnemo z napenjanjem. Pri uporabi vrvnih [škripcev](skripec) se trak med primežem in banano sprosti in ga moramo sproti ročno vleči v banano. To ni potrebno, če je banana sama del napenjalnega sistema (na primer v kombinaciji z [mačkom](macek)). Ko nam zmanjka hoda v napenjalnem sistemu ali ko pride primež preblizu banane, silo v napenjalnem sistemu popustimo in primež ponovno premaknemo naprej po traku. Postopek ponavljamo do želene [napetosti](napetost), nato pa primež odstranimo. Dokler je primež nameščen na trak, po njem ne smemo hoditi!
 
 ## Različice
 
-Na tržišču je najti precej različic primežev. Izmed njih velja omeniti LineGrip,
-ki je najstarejša naprava te sorte in je bila nekaj časa kar sinonim za primež.
-Ta naprava ima kovinski mehanizem in prenese precejšnje sile, a je zato dokaj
-težka. Za njo so se na tržišču začele pojavljati manjše in lažje naprave za
-namensko uporabo na [visokicah](/visokica), kjer so [napetosti](/napetost)
-trakov občutno manjše, teža opreme pa pomembnejša. Pri tej generaciji primežev
-je kovinski mehanizem nadomeščen z močno vrvjo, ki je okoli plošč primeža
-opletena tako, da ju stisne, ko primež izpostavimo sili.
+Na tržišču je najti precej različic primežev. Izmed njih velja omeniti LineGrip, ki je najstarejša naprava te sorte in je bila nekaj časa kar sinonim za primež. Ta naprava ima kovinski mehanizem in prenese precejšnje sile, a je zato dokaj težka. Za njo so se na tržišču začele pojavljati manjše in lažje naprave za namensko uporabo na [visokicah](visokica), kjer so [napetosti](napetost) trakov občutno manjše, teža opreme pa pomembnejša. Pri tej generaciji primežev je kovinski mehanizem nadomeščen z močno vrvjo, ki je okoli plošč primeža opletena tako, da ju stisne, ko primež izpostavimo sili.
 
-Primež si s pravimi materiali ter nekaj spretnosti in truda lahko izdelamo tudi
-sami. Na spletu so objavljena navodila za izdelavo primeža iz lesa (t.i.
-WoodGrip), najti pa je mogoče celo načrte za tiskanje primeža s 3D-tiskalnikom.
+Primež si s pravimi materiali ter nekaj spretnosti in truda lahko izdelamo tudi sami. Na spletu so objavljena navodila za izdelavo primeža iz lesa (t.i. WoodGrip), najti pa je mogoče celo načrte za tiskanje primeža s 3D-tiskalnikom.
 
 ![LineGrip](images/linegrip.jpg)

--- a/src/wiki/raztezek.md
+++ b/src/wiki/raztezek.md
@@ -1,24 +1,7 @@
 # Raztezek
 
-_Raztezek_ je ena od lastnosti [traku](/trak) in je merilo za kvalitativno
-lastnost elastičnosti. Trak z večjim raztezkom se bo pri isti sili raztegnil
-bolj kot trak z manjšim raztezkom. Raztezek podajamo v procentih pri nazivni
-sili. Primer: če ima trak raztezek 8 % pri 10 kN, to pomeni, da se bo pri
-obremenitvi z 10 kN raztegnil za 8 % prvotne dolžine.
+_Raztezek_ je ena od lastnosti [traku](trak) in je merilo za kvalitativno lastnost elastičnosti. Trak z večjim raztezkom se bo pri isti sili raztegnil bolj kot trak z manjšim raztezkom. Raztezek podajamo v procentih pri nazivni sili. Primer: če ima trak raztezek 8 % pri 10 kN, to pomeni, da se bo pri obremenitvi z 10 kN raztegnil za 8 % prvotne dolžine.
 
-Razteznostne karakteristike trakov v splošnem niso linearne, kar še zlasti velja
-za poliamidne (najlonske) trakove. To pomeni, da za trak iz zgoraj omenjenega
-primera ne moremo nujno sklepati, da se bo pri polovici nazivne sile (5 kN)
-raztegnil za 4 %. Če potrebujemo točno vrednost raztezka pri dani sili, je edina
-rešitev, da pogledamo na diagram raztezka v odvisnosti od sile. Na žalost tak
-diagram ni vedno na razpolago, za _de facto_ standard pa je trenutno
-uveljavljeno navajanje raztezka pri 10 kN, kar je precej izven območja, v
-katerem se običajno gibljejo [napetosti](/napetost) trakov. Nekateri
-proizvajalci so težavo že pripoznali in začeli navajati raztezke pri več silah,
-na primer za 5 kN ter 10 kN.
+Razteznostne karakteristike trakov v splošnem niso linearne, kar še zlasti velja za poliamidne (najlonske) trakove. To pomeni, da za trak iz zgoraj omenjenega primera ne moremo nujno sklepati, da se bo pri polovici nazivne sile (5 kN) raztegnil za 4 %. Če potrebujemo točno vrednost raztezka pri dani sili, je edina rešitev, da pogledamo na diagram raztezka v odvisnosti od sile. Na žalost tak diagram ni vedno na razpolago, za _de facto_ standard pa je trenutno uveljavljeno navajanje raztezka pri 10 kN, kar je precej izven območja, v katerem se običajno gibljejo [napetosti](napetost) trakov. Nekateri proizvajalci so težavo že pripoznali in začeli navajati raztezke pri več silah, na primer za 5 kN ter 10 kN.
 
-Krajši trakovi z velikimi raztezki se uporabljajo za dinamične
-[slackline](/slackline) v parkih, uporaba daljših zelo raztegljivih trakov pa je
-skoraj izključno omejena na [visokice](/visokica), kjer velik poves ni ovira.
-Trakovi srednjih raztegljivosti (poliester) so uporabni vsestransko, trakovi z
-nizkimi raztegljivostmi pa so priljubljeni predvsem za zelo dolge relacije.
+Krajši trakovi z velikimi raztezki se uporabljajo za dinamične [slackline](slackline) v parkih, uporaba daljših zelo raztegljivih trakov pa je skoraj izključno omejena na [visokice](visokica), kjer velik poves ni ovira. Trakovi srednjih raztegljivosti (poliester) so uporabni vsestransko, trakovi z nizkimi raztegljivostmi pa so priljubljeni predvsem za zelo dolge relacije.

--- a/src/wiki/redundanca.md
+++ b/src/wiki/redundanca.md
@@ -1,32 +1,9 @@
 # Redundanca
 
-_Redundanca_ je stanje, ko isto vlogo opravlja več neodvisnih podsistemov, s
-čimer dosežemo odpornost na odpoved enega od njih. V visokovanju je najočitnejši
-primer redundance uporaba dveh trakov: [glavnega](/glavni-trak) in
-[pomožnega](/pomozni-trak). Če iz kakršnegakoli razloga glavni trak odpove,
-nosilno vlogo prevzame rezervni trak in s tem obvaruje visokovalca pred padcem v
-globino.
+_Redundanca_ je stanje, ko isto vlogo opravlja več neodvisnih podsistemov, s čimer dosežemo odpornost na odpoved enega od njih. V visokovanju je najočitnejši primer redundance uporaba dveh trakov: [glavnega](glavni-trak) in [pomožnega](pomozni-trak). Če iz kakršnegakoli razloga glavni trak odpove, nosilno vlogo prevzame rezervni trak in s tem obvaruje visokovalca pred padcem v globino.
 
-Pri [postavljanju](/postavljanje) visokice je treba poskrbeti, da so redundantne
-vse komponente, katerih odpoved je v razumni meri mogoča. Edini neredundantni
-deli sistema so [vis](/vis), pri katerem je redundanco v praksi težko doseči
-brez povzročanja drugih težav, ter v določenih primerih objekti, na katere je
-visokica sidrana. Pri postavljanju [sidrišča](/sidrisce) na drevesu ali skali
-lahko, na primer, ocenimo, da je dotičen objekt dovolj velik, močan in stabilen,
-da odpovedi _celega_ objekta (prevrnitev drevesa, premik skale) ni pričakovati.
-V primeru sidranja na vijake v sicer stabilni skali je treba obremenitev vseeno
-razporediti po več točkah, saj se lahko kateri od vijakov zaradi krajevnih
-variacij v kakovosti skale izpuli.
+Pri [postavljanju](postavljanje) visokice je treba poskrbeti, da so redundantne vse komponente, katerih odpoved je v razumni meri mogoča. Edini neredundantni deli sistema so [vis](vis), pri katerem je redundanco v praksi težko doseči brez povzročanja drugih težav, ter v določenih primerih objekti, na katere je visokica sidrana. Pri postavljanju [sidrišča](sidrisce) na drevesu ali skali lahko, na primer, ocenimo, da je dotičen objekt dovolj velik, močan in stabilen, da odpovedi _celega_ objekta (prevrnitev drevesa, premik skale) ni pričakovati. V primeru sidranja na vijake v sicer stabilni skali je treba obremenitev vseeno razporediti po več točkah, saj se lahko kateri od vijakov zaradi krajevnih variacij v kakovosti skale izpuli.
 
-Glavni način doseganja redundance je podvajanje komponent: za izdelavo sidrišča
-uporabimo dve zanki, glavni trak ter rezervo vpnemo v ločene vezne člene,
-obremenitev razporedimo po več sidriščnih točkah. Za doseganje dodatne
-redundance lahko neobremenjen preostanek trakov visokice privežemo še na ločen
-objekt (na primer okoli drugega drevesa).
+Glavni način doseganja redundance je podvajanje komponent: za izdelavo sidrišča uporabimo dve zanki, glavni trak ter rezervo vpnemo v ločene vezne člene, obremenitev razporedimo po več sidriščnih točkah. Za doseganje dodatne redundance lahko neobremenjen preostanek trakov visokice privežemo še na ločen objekt (na primer okoli drugega drevesa).
 
-Redundantnost sistema prevprašamo tako, da za vsako od komponent razmislimo, kaj
-se zgodi, če ta odpove. Sistem je dovolj redundanten v primeru, da odpoved
-katerekoli komponente povzroči le prenos sile na drugo. Pri oceni redundantnosti
-je treba posebno pozornost posvetiti možnosti
-[verižne odpovedi](/verizna-odpoved), ki lahko usodno prizadene tudi na videz
-polno redundanten sistem.
+Redundantnost sistema prevprašamo tako, da za vsako od komponent razmislimo, kaj se zgodi, če ta odpove. Sistem je dovolj redundanten v primeru, da odpoved katerekoli komponente povzroči le prenos sile na drugo. Pri oceni redundantnosti je treba posebno pozornost posvetiti možnosti [verižne odpovedi](verizna-odpoved), ki lahko usodno prizadene tudi na videz polno redundanten sistem.

--- a/src/wiki/segmentiranje.md
+++ b/src/wiki/segmentiranje.md
@@ -1,76 +1,26 @@
 # Segmentiranje
 
-_Segmentiranje_ je tehnika, pri kateri [visokico](/visokica) sestavimo iz več
-zaporednih kosov [trakov](/trak) (segmentov). Na vsakem od spojev sta trakova,
-tako [glavni](/glavni-trak) kot [pomožni](/pomozni-trak), med seboj navzkrižno
-povezana preko veznih členov, speljanih skozi [šivane zanke](/sivana-zanka).
-Tehnika se uporablja za [postavljanje](/postavljanje) visokic, daljših od 100 m,
-kjer bi bila uporaba enega samega zveznega traku nepraktična in tudi potencialno
-nevarna.
+_Segmentiranje_ je tehnika, pri kateri [visokico](visokica) sestavimo iz več zaporednih kosov [trakov](trak) (segmentov). Na vsakem od spojev sta trakova, tako [glavni](glavni-trak) kot [pomožni](pomozni-trak), med seboj navzkrižno povezana preko veznih členov, speljanih skozi [šivane zanke](sivana-zanka). Tehnika se uporablja za [postavljanje](postavljanje) visokic, daljših od 100 m, kjer bi bila uporaba enega samega zveznega traku nepraktična in tudi potencialno nevarna.
 
 ## Praktični vidik
 
 Segmentiranje ima znatne praktične prednosti pri postavljanju dolgih visokic:
 
-- Prenašanje opreme na lokacijo je lažje: posamezne kose trakov lahko
-  razporedimo med več nosačev in trakove sestavimo šele na licu mesta.
-- Za vsako visokico prinesemo le toliko traku, kolikor ga zares potrebujemo.
-- Kombiniramo lahko obstoječe trakove različnih lastnikov – ni treba nabavljati
-  namenskih dolgih trakov za velike projekte.
-- Če pride do poškodbe kakega od segmentov, to ne preprečuje nadaljnje uporabe
-  vseh ostalih.
+* Prenašanje opreme na lokacijo je lažje: posamezne kose trakov lahko razporedimo med več nosačev in trakove sestavimo šele na licu mesta.
+* Za vsako visokico prinesemo le toliko traku, kolikor ga zares potrebujemo.
+* Kombiniramo lahko obstoječe trakove različnih lastnikov – ni treba nabavljati namenskih dolgih trakov za velike projekte.
+* Če pride do poškodbe kakega od segmentov, to ne preprečuje nadaljnje uporabe vseh ostalih.
 
 ## Varnostni vidik
 
-Čeprav so že omenjene praktične prednosti več kot dovoljšen razlog za
-segmentiranje, ima tehnika tudi zelo pomembno varnostno prednost. Poglejmo, kaj
-se zgodi v primeru morebitne odpovedi glavnega traku na nesegmentirani visokici.
-Ker je [pomožni trak](/pomozni-trak) daljši od [glavnega](/glavni-trak), pri
-odpovedi slednjega visokovalec najprej nekaj časa pada, preden ga pomožni trak
-prestreže. Daljši kot je padec, večja je sila, ki so ji naposled izpostavljeni
-tako visokovalec kot [sidrišča](/sidrisce). Pri kratkih visokicah je razlika
-dolžin glavnega in pomožnega traku majhna, padec ni globok in sile ostanejo
-znotraj varnih meja. Podoba pa je precej drugačna pri dolgih trakovih: tam je
-omenjena razlika dolžin trakov večja in padci na pomožni trak lahko dosežejo
-precejšnje globine. Posledično so tudi sile na visokovalca in sidrišča velike in
-lahko privedejo do telesnih poškodb ali celo odpovedi opreme.
+Čeprav so že omenjene praktične prednosti več kot dovoljšen razlog za segmentiranje, ima tehnika tudi zelo pomembno varnostno prednost. Poglejmo, kaj se zgodi v primeru morebitne odpovedi glavnega traku na nesegmentirani visokici. Ker je [pomožni trak](pomozni-trak) daljši od [glavnega](glavni-trak), pri odpovedi slednjega visokovalec najprej nekaj časa pada, preden ga pomožni trak prestreže. Daljši kot je padec, večja je sila, ki so ji naposled izpostavljeni tako visokovalec kot [sidrišča](sidrisce). Pri kratkih visokicah je razlika dolžin glavnega in pomožnega traku majhna, padec ni globok in sile ostanejo znotraj varnih meja. Podoba pa je precej drugačna pri dolgih trakovih: tam je omenjena razlika dolžin trakov večja in padci na pomožni trak lahko dosežejo precejšnje globine. Posledično so tudi sile na visokovalca in sidrišča velike in lahko privedejo do telesnih poškodb ali celo odpovedi opreme.
 
-Segmentiranje to težavo rešuje: če pride do odpovedi glavnega traku, popusti le
-tisti segment, kjer se je odpoved zgodila. Cel trak se zato efektivno podaljša
-le za razliko dolžin glavnega in pomožnega traku v enem segmentu, in še to
-podaljšanje se v veliki meri kompenzira s skrčitvijo glavnega traku v
-neprizadetih segmentih. Padec na pomožni trak je zato znatno krajši in blažji.
+Segmentiranje to težavo rešuje: če pride do odpovedi glavnega traku, popusti le tisti segment, kjer se je odpoved zgodila. Cel trak se zato efektivno podaljša le za razliko dolžin glavnega in pomožnega traku v enem segmentu, in še to podaljšanje se v veliki meri kompenzira s skrčitvijo glavnega traku v neprizadetih segmentih. Padec na pomožni trak je zato znatno krajši in blažji.
 
 ## Sestavljanje segmentov
 
-Vsak segment sestavljata en glavni in en pomožni trak. Pomožni trak mora biti
-ustrezno daljši od glavnega: ko je segment enkrat povezan v visokico,
-prilagajanje dolžine pomožnega traku ni več mogoče, zato morajo biti prave
-dolžine pazljivo pripravljene vnaprej. Ker so trakovi običajno standardnih
-dolžin (najpogosteje 50 m ali 100 m), sta na začetku oba trakova v paru enake
-dolžine in je treba pomožni trak nekako podaljšati. To lahko storimo na več
-načinov, a najbolje se obnesejo podaljški iz traku, ki jih na pomožni trak
-namestimo tako, da šivani zanki traku in podaljška povežemo s
-[kavbojskim vozlom](/kavbojski-vozel). Dolžina podaljška je odvisna od
-[raztezka](/raztezek) glavnega traku in predvidene končne [napetosti](/napetost)
-visokice.
+Vsak segment sestavljata en glavni in en pomožni trak. Pomožni trak mora biti ustrezno daljši od glavnega: ko je segment enkrat povezan v visokico, prilagajanje dolžine pomožnega traku ni več mogoče, zato morajo biti prave dolžine pazljivo pripravljene vnaprej. Ker so trakovi običajno standardnih dolžin (najpogosteje 50 m ali 100 m), sta na začetku oba trakova v paru enake dolžine in je treba pomožni trak nekako podaljšati. To lahko storimo na več načinov, a najbolje se obnesejo podaljški iz traku, ki jih na pomožni trak namestimo tako, da šivani zanki traku in podaljška povežemo s [kavbojskim vozlom](kavbojski-vozel). Dolžina podaljška je odvisna od [raztezka](raztezek) glavnega traku in predvidene končne [napetosti](napetost) visokice.
 
-Tako pripravljene pare trakov povežemo med seboj z navzkrižnimi spoji, ki
-zmorejo silo s kateregakoli traku na eni strani spoja prenesti na katerikoli
-trak na drugi strani. Obremenitev tako lahko poteka v smeri glavni–glavni
-(običajen režim delovanja), glavni–pomožni (v primeru odpovedi glavnega traku v
-enem segmentu) ali celo v smeri pomožni–pomožni (v sicer zelo malo verjetnem, a
-teoretično mogočem primeru odpovedi glavnih trakov v obeh segmentih). Navzkrižni
-spoji so izdelani z [vrvnimi škopci](/vrvni-skopec).[^1] Obstaja
-več tipov vezave, od katerih bomo tu omenili le eno. Pri tej vezavi šivano zanko
-pomožnega traku vstavimo v šivano zanko glavnega traku, nato pa obe tako
-pripravljeni strani povežemo z dvema vrvnima škopcema (s tem zagotovimo
-[redundantnost](/redundanca) povezave). Izdelane spoje navadno na koncu povijemo
-z lepilnim trakom, ki komponente spoja drži na mestu, hkrati pa zmanjša možnost
-zatikanja kovinskih obročev [visa](/vis) pri prehodu preko spoja.
+Tako pripravljene pare trakov povežemo med seboj z navzkrižnimi spoji, ki zmorejo silo s kateregakoli traku na eni strani spoja prenesti na katerikoli trak na drugi strani. Obremenitev tako lahko poteka v smeri glavni–glavni (običajen režim delovanja), glavni–pomožni (v primeru odpovedi glavnega traku v enem segmentu) ali celo v smeri pomožni–pomožni (v sicer zelo malo verjetnem, a teoretično mogočem primeru odpovedi glavnih trakov v obeh segmentih). Navzkrižni spoji so izdelani z [vrvnimi škopci](vrvni-skopec).[^1] Obstaja več tipov vezave, od katerih bomo tu omenili le eno. Pri tej vezavi šivano zanko pomožnega traku vstavimo v šivano zanko glavnega traku, nato pa obe tako pripravljeni strani povežemo z dvema vrvnima škopcema (s tem zagotovimo [redundantnost](redundanca) povezave). Izdelane spoje navadno na koncu povijemo z lepilnim trakom, ki komponente spoja drži na mestu, hkrati pa zmanjša možnost zatikanja kovinskih obročev [visa](vis) pri prehodu preko spoja.
 
-[^1]: Včasih se uporablja tudi kombinacija vrvnega škopca in [ovalnega
-    člena](/ovalni-clen), vendar slednji zaradi svoje mase lahko predstavlja
-    nevarnost. V primeru odpovedi segmenta ga namreč lahko hipen sunek traku
-    ob prerazporeditvi sile zažene v visokovalca in ga poškoduje. Uporaba
-    ovalnih členov zato ni najbolj priporočljiva.
+[^1]: Včasih se uporablja tudi kombinacija vrvnega škopca in [ovalnega člena](ovalni-clen), vendar slednji zaradi svoje mase lahko predstavlja nevarnost. V primeru odpovedi segmenta ga namreč lahko hipen sunek traku ob prerazporeditvi sile zažene v visokovalca in ga poškoduje. Uporaba ovalnih členov zato ni najbolj priporočljiva.

--- a/src/wiki/sidrisce.md
+++ b/src/wiki/sidrisce.md
@@ -1,69 +1,17 @@
 # Sidrišče
 
-_Sidrišče_ je sistem veznih elementov, ki so na eni strani pripeti na okolico,
-na drugi strani pa se združijo v [skupni točki](/skupna-tocka), v katero je vpet
-[slackline](/slackline). Izdelava sidrišč je prvi korak pri
-[postavljanju](/postavljanje). Sidrišča se v grobem ločijo na dve vrsti glede na
-način pritrditve: objekte, na katere sidramo, lahko bodisi ovijemo z
-[zankami](/neskoncna-zanka) ali vrvmi bodisi izkoristimo sidriščne točke, ki so
-na objekte pritrjene. Najpogostejši primer ovijanja je sidranje na drevesa,
-sidranje v pritrjene točke pa se uporablja pri skalnih sidriščih. [Trak](/Trak)
-je v skupno točko sidrišča vpet z [banano](/banana) ali
-[šivano zanko](/sivana-zanka). Vezne elemente sidrišča je treba ustrezno
-zaščititi pred [abrazijo](/abrazija), pri [visokicah](/visokica) pa je treba
-poskrbeti tudi za [redundanco](/redundanca).
+_Sidrišče_ je sistem veznih elementov, ki so na eni strani pripeti na okolico, na drugi strani pa se združijo v [skupni točki](skupna-tocka), v katero je vpet [slackline](slackline). Izdelava sidrišč je prvi korak pri [postavljanju](postavljanje). Sidrišča se v grobem ločijo na dve vrsti glede na način pritrditve: objekte, na katere sidramo, lahko bodisi ovijemo z [zankami](neskoncna-zanka) ali vrvmi bodisi izkoristimo sidriščne točke, ki so na objekte pritrjene. Najpogostejši primer ovijanja je sidranje na drevesa, sidranje v pritrjene točke pa se uporablja pri skalnih sidriščih. [Trak](trak) je v skupno točko sidrišča vpet z [banano](banana) ali [šivano zanko](sivana-zanka). Vezne elemente sidrišča je treba ustrezno zaščititi pred [abrazijo](abrazija), pri [visokicah](visokica) pa je treba poskrbeti tudi za [redundanco](redundanca).
 
 ## Sidrišča na drevesih
 
-Sidranje na drevesa je najpogostejši način pritrjevanja slacklinov. Za
-postavljanje takega sidrišča navadno uporabimo [tovorno](/tovorna-zanka) ali
-drugo [neskončno zanko](/neskoncna-zanka), ki jo ovijemo okoli drevesa.
-Uporabiti je mogoče tudi statično vrv, a je ta izbira manj priporočljiva, saj
-vrv močneje pritiska na skorjo drevesa kot ploščati trak zanke. V vseh primerih
-je treba drevo pred drgnjenjem zaščititi s [podlogo](/podloga). Zanko lahko na
-drevo namestimo v konfiguraciji koša (ovijemo jo okoli drevesa in združimo
-konca) ali pa jo nanj zavežemo s [kavbojskim vozlom](/kavbojski-vozel). Zanka v
-konfiguraciji koša ima večjo nosilnost, a tudi slabo lastnost, da neobremenjena
-med postavljanjem zdrsava navzdol po deblu. Zdrsavanje lahko preprečimo tako, da
-jo pripnemo na podlogo, s katero smo zaščitili drevo (na primer z uporabo
-trakcev z "ježkom"). Kavbojski vozel trdno objame drevo in s tem že sam prepreči
-zdrsavanje, a je njegova nosilnost nekoliko manjša, poleg tega pa se prosti
-konec zanke lahko suka in se moramo zato nekoliko potruditi, če želimo slackline
-vpeti vodoravno. V obeh konfiguracijah na zanko v [skupni točki](/skupna-tocka)
-namestimo [škopec](/skopec), nanj pa bodisi [banano](/banana) ali neposredno
-[šivano zanko](/sivana-zanka) traku.
+Sidranje na drevesa je najpogostejši način pritrjevanja slacklinov. Za postavljanje takega sidrišča navadno uporabimo [tovorno](tovorna-zanka) ali drugo [neskončno zanko](neskoncna-zanka), ki jo ovijemo okoli drevesa. Uporabiti je mogoče tudi statično vrv, a je ta izbira manj priporočljiva, saj vrv močneje pritiska na skorjo drevesa kot ploščati trak zanke. V vseh primerih je treba drevo pred drgnjenjem zaščititi s [podlogo](podloga). Zanko lahko na drevo namestimo v konfiguraciji koša (ovijemo jo okoli drevesa in združimo konca) ali pa jo nanj zavežemo s [kavbojskim vozlom](kavbojski-vozel). Zanka v konfiguraciji koša ima večjo nosilnost, a tudi slabo lastnost, da neobremenjena med postavljanjem zdrsava navzdol po deblu. Zdrsavanje lahko preprečimo tako, da jo pripnemo na podlogo, s katero smo zaščitili drevo (na primer z uporabo trakcev z "ježkom"). Kavbojski vozel trdno objame drevo in s tem že sam prepreči zdrsavanje, a je njegova nosilnost nekoliko manjša, poleg tega pa se prosti konec zanke lahko suka in se moramo zato nekoliko potruditi, če želimo slackline vpeti vodoravno. V obeh konfiguracijah na zanko v [skupni točki](skupna-tocka) namestimo [škopec](skopec), nanj pa bodisi [banano](banana) ali neposredno [šivano zanko](sivana-zanka) traku.
 
-Pri sidranju [visokice](/visokica) je treba drevo pazljivo izbrati: biti mora
-dovolj močno in stabilno, da ga sile pri uporabi visokice ne morejo podreti. Če
-imamo kakršnekoli dvome v stabilnost sicer dovolj močnega drevesa, situacije
-_nikakor_ ne rešujemo tako, da [pomožni trak](/pomozni-trak) ali neobremenjena
-repa [glavnega](/glavni-trak) in pomožnega traku privežemo na drugo drevo: če se
-primarno drevo podre, lahko namreč s svojo težo preobremeni trakove in privede
-do [verižne odpovedi](/verizna-odpoved). V takšnih primerih je edini dovolj
-varen način zaščite to, da samo drevo dodatno zavarujemo tako, da ga z vrvmi
-privežemo na druga drevesa za njim. Če se primarno drevo preveč nagne, vrvi
-prenesejo del obremenitve na sekundarna drevesa in s tem obvarujejo primarno
-drevo pred podrtjem. Varovalne vrvi moramo čim bolj napeti, da v primeru nagiba
-drevesa takoj začnejo prenašati silo naprej.
+Pri sidranju [visokice](visokica) je treba drevo pazljivo izbrati: biti mora dovolj močno in stabilno, da ga sile pri uporabi visokice ne morejo podreti. Če imamo kakršnekoli dvome v stabilnost sicer dovolj močnega drevesa, situacije _nikakor_ ne rešujemo tako, da [pomožni trak](pomozni-trak) ali neobremenjena repa [glavnega](glavni-trak) in pomožnega traku privežemo na drugo drevo: če se primarno drevo podre, lahko namreč s svojo težo preobremeni trakove in privede do [verižne odpovedi](verizna-odpoved). V takšnih primerih je edini dovolj varen način zaščite to, da samo drevo dodatno zavarujemo tako, da ga z vrvmi privežemo na druga drevesa za njim. Če se primarno drevo preveč nagne, vrvi prenesejo del obremenitve na sekundarna drevesa in s tem obvarujejo primarno drevo pred podrtjem. Varovalne vrvi moramo čim bolj napeti, da v primeru nagiba drevesa takoj začnejo prenašati silo naprej.
 
-Če imamo namesto enega močnega drevesa na voljo le več šibkejših, lahko sidrišče
-izdelamo tako, da do vsakega od njih speljemo svoj niz zank ali vrv, njihova
-krajišča pa združimo v [skupni točki](/skupna-tocka). Pri tem moramo nujno
-poskrbeti, da se sila iz skupne točke enakomerno porazdeli med drevesa.
+Če imamo namesto enega močnega drevesa na voljo le več šibkejših, lahko sidrišče izdelamo tako, da do vsakega od njih speljemo svoj niz zank ali vrv, njihova krajišča pa združimo v [skupni točki](skupna-tocka). Pri tem moramo nujno poskrbeti, da se sila iz skupne točke enakomerno porazdeli med drevesa.
 
 ## Sidrišča v skali
 
 ![Sidrišče](images/sidrisce.jpg)
 
-Skalna sidrišča lahko v nekaterih primerih izvedemo z ovijanjem, in v tem
-primeru veljajo podobna pravila kot pri izdelavi sidrišč na drevesu. Kadar skala
-ni primerno oblikovana za ovijanje, pa se moramo poslužiti pritrjevanja s
-skalnimi vijaki. Ker gre v takem primeru skoraj vedno za sidrišče visokice, je
-treba pri zasnovi že razmišljati o [redundanci](/redundanca). V skalo običajno
-namestimo dva do tri vijake. Nanje privijemo kovinska ušesa, skozi slednja pa
-vstavimo bodisi [deltaste člene](/deltasti-clen) (za uporabo s
-[tovornimi zankami](/tovorna-zanka)) bodisi [ovalne člene](/ovalni-clen) (za
-sidrišča s statičnimi vrvmi). Pramene zank ali vrvi zberemo v
-[skupni točki](/skupna-tocka), kjer skoznje vstavimo kovinski vezni člen, na
-primer [škopec](/skopec). Pri uporabi vrvi včasih pred tem vse pramene še
-zavežemo v [jebeno velik vozel](/jebeno-velik-vozel).
+Skalna sidrišča lahko v nekaterih primerih izvedemo z ovijanjem, in v tem primeru veljajo podobna pravila kot pri izdelavi sidrišč na drevesu. Kadar skala ni primerno oblikovana za ovijanje, pa se moramo poslužiti pritrjevanja s skalnimi vijaki. Ker gre v takem primeru skoraj vedno za sidrišče visokice, je treba pri zasnovi že razmišljati o [redundanci](redundanca). V skalo običajno namestimo dva do tri vijake. Nanje privijemo kovinska ušesa, skozi slednja pa vstavimo bodisi [deltaste člene](deltasti-clen) (za uporabo s [tovornimi zankami](tovorna-zanka)) bodisi [ovalne člene](ovalni-clen) (za sidrišča s statičnimi vrvmi). Pramene zank ali vrvi zberemo v [skupni točki](skupna-tocka), kjer skoznje vstavimo kovinski vezni člen, na primer [škopec](skopec). Pri uporabi vrvi včasih pred tem vse pramene še zavežemo v [jebeno velik vozel](jebeno-velik-vozel).

--- a/src/wiki/sivana-zanka.md
+++ b/src/wiki/sivana-zanka.md
@@ -1,31 +1,9 @@
 # Šivana zanka
 
-_Šivana zanka_ je zaključna zanka na [traku](/trak), ki omogoča vpetje traku
-brez uporabe [banane](/banana). Izdelana je tako, da je konec traku zapognjen
-sam preko sebe, nato pa zašit s posebnim šivom v dolžini približno 10 do 15 cm.
-Za izboljšanje nosilnosti je včasih trak zavit v več kot dve plasti ali pa je v
-zapognjeni konec traku vstavljena še dodatna plast drugega traku. Šivana zanka v
-splošnem povzroči nekaj izgube nosilnosti, a sodobne, profesionalno izdelane
-šivane zanke se že močno približajo
-[minimalni porušni sili](/minimalna-porusna-sila) samega traku (več kot 90 %).
-Izdelavo šivanih zank je najbolje prepustiti proizvajalcu, saj ta najbolje pozna
-značilnosti traku ter tehniko šivanja, ki da najboljše rezultate.
+_Šivana zanka_ je zaključna zanka na [traku](trak), ki omogoča vpetje traku brez uporabe [banane](banana). Izdelana je tako, da je konec traku zapognjen sam preko sebe, nato pa zašit s posebnim šivom v dolžini približno 10 do 15 cm. Za izboljšanje nosilnosti je včasih trak zavit v več kot dve plasti ali pa je v zapognjeni konec traku vstavljena še dodatna plast drugega traku. Šivana zanka v splošnem povzroči nekaj izgube nosilnosti, a sodobne, profesionalno izdelane šivane zanke se že močno približajo [minimalni porušni sili](minimalna-porusna-sila) samega traku (več kot 90 %). Izdelavo šivanih zank je najbolje prepustiti proizvajalcu, saj ta najbolje pozna značilnosti traku ter tehniko šivanja, ki da najboljše rezultate.
 
 ![Šivane zanke](images/sivane-zanke.jpg)
 
-Šivane zanke imajo dve glavni uporabi: prva je vpenjanje traku na
-[statični strani](/staticna-stran), kjer zanko preprosto vstavimo v
-[škopec](/skopec) in se s tem izognemo potrebi po dodatni banani. Pri
-postavljanju [visokic](/visokica) je opremo pogosto treba nositi v hrib in vsako
-zmanjšanje njene teže je zato zelo dobrodošlo. Druga glavna uporaba šivanih zank
-je spajanje koncev pri postavljanju [segmentiranih](/segmentiranje) trakov. Pri
-tem krajni zanki dveh segmentov povežemo z [vrvnim škopcem](/vrvni-skopec) ali
-[ovalnim členom](/ovalni-clen).
+Šivane zanke imajo dve glavni uporabi: prva je vpenjanje traku na [statični strani](staticna-stran), kjer zanko preprosto vstavimo v [škopec](skopec) in se s tem izognemo potrebi po dodatni banani. Pri postavljanju [visokic](visokica) je opremo pogosto treba nositi v hrib in vsako zmanjšanje njene teže je zato zelo dobrodošlo. Druga glavna uporaba šivanih zank je spajanje koncev pri postavljanju [segmentiranih](segmentiranje) trakov. Pri tem krajni zanki dveh segmentov povežemo z [vrvnim škopcem](vrvni-skopec) ali [ovalnim členom](ovalni-clen).
 
-Širok razmah uporabe segmentiranih trakov je povzročil, da proizvajalci trakov
-že kar ob naročilu kosa traku ponudijo izdelavo šivanih zank na njegovih koncih.
-Ponudbo zagotovo velja sprejeti, če obstaja vsaj zmerna možnost, da bo trak kdaj
-postavljen na visokici, saj v tem primeru šivane zanke precej povečajo njegovo
-uporabnost. A pred naročilom je vendarle modro preveriti, da proizvajalec daje
-zanesljivo jamstvo za svoj izdelek - za šivane zanke mora biti vedno naveden
-vsaj podatek o zagotovljeni [minimalni porušni sili](/minimalna-porusna-sila).
+Širok razmah uporabe segmentiranih trakov je povzročil, da proizvajalci trakov že kar ob naročilu kosa traku ponudijo izdelavo šivanih zank na njegovih koncih. Ponudbo zagotovo velja sprejeti, če obstaja vsaj zmerna možnost, da bo trak kdaj postavljen na visokici, saj v tem primeru šivane zanke precej povečajo njegovo uporabnost. A pred naročilom je vendarle modro preveriti, da proizvajalec daje zanesljivo jamstvo za svoj izdelek – za šivane zanke mora biti vedno naveden vsaj podatek o zagotovljeni [minimalni porušni sili](minimalna-porusna-sila).

--- a/src/wiki/skopec.md
+++ b/src/wiki/skopec.md
@@ -1,24 +1,7 @@
 # Škopec
 
-_Škopec_ je kovinski vezni člen, najpogosteje podkvaste oblike. Ustje škopca je
-premoščeno z odstranljivim vijakom, ki povezuje kovinski lok v sklenjeno celoto.
-Ko je škopec zaprt, je povsem rigiden in lahko prenese visoke obremenitve v
-praktično vseh smereh, vključno s [trosmernimi](/trosmerna-obremenitev) ali
-večsmernimi obremenitvami. Ta lastnost je glavna prednost škopca pred
-[vponko](/vponka), ki je zasnovana samo za dvosmerno obremenitev. Po škopcu
-posežemo v primerih, ko je treba združiti povezave (vrvi, zanke) z več smeri.
+_Škopec_ je kovinski vezni člen, najpogosteje podkvaste oblike. Ustje škopca je premoščeno z odstranljivim vijakom, ki povezuje kovinski lok v sklenjeno celoto. Ko je škopec zaprt, je povsem rigiden in lahko prenese visoke obremenitve v praktično vseh smereh, vključno s [trosmernimi](trosmerna-obremenitev) ali večsmernimi obremenitvami. Ta lastnost je glavna prednost škopca pred [vponko](vponka), ki je zasnovana samo za dvosmerno obremenitev. Po škopcu posežemo v primerih, ko je treba združiti povezave (vrvi, zanke) z več smeri.
 
-V visokovanju se škopce uporablja kot [skupno točko](/skupna-tocka) na
-[sidriščih](/sidrisce), kjer so na lok škopca pripete
-[tovorne zanke](/tovorna-zanka) in/ali vrvi s sidrišča (skala, drevo), na vijak
-škopca pa krajišče [visokice](/visokica). Vijak škopca lahko obenem služi tudi
-kot ena od osi [popuščalke](/popuscalka). Najpogostejši so škopci z debelino
-loka 12 milimetrov, in sicer zato, ker je izpostavljeni del vijaka ravno prav
-širok, da vanj sede [trak](/trak) ali [šivana zanka](/sivana-zanka). Škopci
-drugih velikosti so v visokovanju manj pogosti, še redkeje pa srečamo škopce v
-obliki črke U ter zasukane škopce. Pri slednjih je ustje zasukano za 90 stopinj
-glede na lok škopca, kar je včasih koristno za povezovanje zank, ki so nameščene
-v pravokotnih smereh.
+V visokovanju se škopce uporablja kot [skupno točko](skupna-tocka) na [sidriščih](sidrisce), kjer so na lok škopca pripete [tovorne zanke](tovorna-zanka) in/ali vrvi s sidrišča (skala, drevo), na vijak škopca pa krajišče [visokice](visokica). Vijak škopca lahko obenem služi tudi kot ena od osi [popuščalke](popuscalka). Najpogostejši so škopci z debelino loka 12 milimetrov, in sicer zato, ker je izpostavljeni del vijaka ravno prav širok, da vanj sede [trak](trak) ali [šivana zanka](sivana-zanka). Škopci drugih velikosti so v visokovanju manj pogosti, še redkeje pa srečamo škopce v obliki črke U ter zasukane škopce. Pri slednjih je ustje zasukano za 90 stopinj glede na lok škopca, kar je včasih koristno za povezovanje zank, ki so nameščene v pravokotnih smereh.
 
-Vezni člen s podobno uporabo, a povsem drugačno izvedbo, je
-[vrvni škopec](/vrvni-skopec).
+Vezni člen s podobno uporabo, a povsem drugačno izvedbo, je [vrvni škopec](vrvni-skopec).

--- a/src/wiki/skripec.md
+++ b/src/wiki/skripec.md
@@ -1,11 +1,3 @@
 # Škripec
 
-_Škripec_ je naprava, preko katere napeljemo vrv, da jo preusmerimo. Sestavljen
-je iz ohišja, osi ter kolesca z utorom, v katerega sede vrv. Posebna sorta
-škripca, v kateri se namesto vrvi uporablja [trak](/trak), je [maček](/macek).
-Najpogostejša uporaba škripcev pri [slacklinu](/slackline) je za sestavljanje
-[napenjalnih sistemov](/napenjalni-sistem), v katerih več škripcev povežemo
-tako, da dosežemo pomnožitev vlečne sile. Kot primitiven škripec lahko uporabimo
-tudi kovinski vezni element brez gibljivih delov, na primer [vponko](/vponka)
-ali kovinski obroč, a z zavedanjem, da trenje zelo zmanjša učinkovitost takega
-škripca in povzroči hitrejšo obrabo vrvi ali traku, ki ga preko njega vlečemo.
+_Škripec_ je naprava, preko katere napeljemo vrv, da jo preusmerimo. Sestavljen je iz ohišja, osi ter kolesca z utorom, v katerega sede vrv. Posebna sorta škripca, v kateri se namesto vrvi uporablja [trak](trak), je [maček](macek). Najpogostejša uporaba škripcev pri [slacklinu](slackline) je za sestavljanje [napenjalnih sistemov](napenjalni-sistem), v katerih več škripcev povežemo tako, da dosežemo pomnožitev vlečne sile. Kot primitiven škripec lahko uporabimo tudi kovinski vezni element brez gibljivih delov, na primer [vponko](vponka) ali kovinski obroč, a z zavedanjem, da trenje zelo zmanjša učinkovitost takega škripca in povzroči hitrejšo obrabo vrvi ali traku, ki ga preko njega vlečemo.

--- a/src/wiki/skupna-tocka.md
+++ b/src/wiki/skupna-tocka.md
@@ -1,14 +1,3 @@
 # Skupna točka
 
-_Skupna točka_ je mesto v [sidrišču](/sidrisce), iz katerega se obremenitev
-porazdeli po posamičnih sidriščnih točkah. Na eni strani so v skupno točko
-speljani vsi povezovalni elementi (vrvi, zanke) s sidriščnih točk, na drugi pa
-sta pripeta trakova visokice. Osrednji vezni člen skupne točke je običajno
-[škopec](/skopec) ali jeklena [vponka](/vponka). Povezave s sidriščnih točk se
-lahko bodisi samo speljane skozi vezni člen bodisi so pred njim zavozlane v
-[jebeno velik vozel](/jebeno-velik-vozel). Oba pristopa imata svoje prednosti in
-slabosti. Pristop z gibljivimi vpetjem omogoča, da zanke in/ali vrvi drsijo
-skozi vezni člen in s tem omogočajo določeno mero samodejnega porazdeljevanja
-sile. Veliki vozel takšnega prerazporejanja ne omogoča, prepreči pa možnost
-hipnih obremenitev v primeru odpovedi ene od sidriščnih točk in s tem
-[verižno odpoved](/verizna-odpoved) sidrišča.
+_Skupna točka_ je mesto v [sidrišču](sidrisce), iz katerega se obremenitev porazdeli po posamičnih sidriščnih točkah. Na eni strani so v skupno točko speljani vsi povezovalni elementi (vrvi, zanke) s sidriščnih točk, na drugi pa sta pripeta trakova visokice. Osrednji vezni člen skupne točke je običajno [škopec](skopec) ali jeklena [vponka](vponka). Povezave s sidriščnih točk se lahko bodisi samo speljane skozi vezni člen bodisi so pred njim zavozlane v [jebeno velik vozel](jebeno-velik-vozel). Oba pristopa imata svoje prednosti in slabosti. Pristop z gibljivimi vpetjem omogoča, da zanke in/ali vrvi drsijo skozi vezni člen in s tem omogočajo določeno mero samodejnega porazdeljevanja sile. Veliki vozel takšnega prerazporejanja ne omogoča, prepreči pa možnost hipnih obremenitev v primeru odpovedi ene od sidriščnih točk in s tem [verižno odpoved](verizna-odpoved) sidrišča.

--- a/src/wiki/skupnost.md
+++ b/src/wiki/skupnost.md
@@ -1,12 +1,8 @@
 # Visokovalska skupnost
 
-Slovenska visokovalska skupnost je v trenutku pisanja še dokaj majhna, a ne
-dvomimo, da se bo s časom le povečevala. Če želiš stopiti v stik s skupnostjo,
-je ponavadi dovolj že, da redno vadiš v parku, in prava poznanstva se bodo
-vzpostavila sama od sebe. Spodaj je zbranih še nekaj spletnih povezav na
-skupine, katerih člani se ukvarjajo z visokovanjem.
+Slovenska visokovalska skupnost je v trenutku pisanja še dokaj majhna, a ne dvomimo, da se bo s časom le povečevala. Če želiš stopiti v stik s skupnostjo, je ponavadi dovolj že, da redno vadiš v parku, in prava poznanstva se bodo vzpostavila sama od sebe. Spodaj je zbranih še nekaj spletnih povezav na skupine, katerih člani se ukvarjajo z visokovanjem.
 
-- [Highline Slovenia](https://www.facebook.com/groups/425847847594412/) (skupina na Facebooku)
-- [SlackAlien](https://www.facebook.com/SlackAlien/) (skupina na Facebooku)
-- [Slackline Slovenj Gradec](https://www.facebook.com/slacklineSG/) (skupina na Facebooku)
-- [Društvo Balansa](https://balansa.si/)
+* [Highline Slovenia](https://www.facebook.com/groups/425847847594412/) (skupina na Facebooku)
+* [SlackAlien](https://www.facebook.com/SlackAlien/) (skupina na Facebooku)
+* [Slackline Slovenj Gradec](https://www.facebook.com/slacklineSG/) (skupina na Facebooku)
+* [Društvo Balansa](https://balansa.si/)

--- a/src/wiki/slackline.md
+++ b/src/wiki/slackline.md
@@ -1,18 +1,14 @@
 # Slackline
 
-_Slackline_ je krovni izraz za dejavnost gibanja na napetem [traku](/trak). Ker
-je definicija tako široka, izraz pokriva več poddejavnosti, ki so opredeljene s
-svojimi specifikami: na primer z dolžino traku, njegovo višino in načinom
-gibanja na njem (hoja, izvajanje trikov). V nespecifični rabi se izraz
-_slackline_ običajno nanaša na krajše trakove, napete na majhni višini, tipično
-v parku.
+_Slackline_ je krovni izraz za dejavnost gibanja na napetem [traku](trak). Ker je definicija tako široka, izraz pokriva več poddejavnosti, ki so opredeljene s svojimi specifikami: na primer z dolžino traku, njegovo višino in načinom gibanja na njem (hoja, izvajanje trikov). V nespecifični rabi se izraz _slackline_ običajno nanaša na krajše trakove, napete na majhni višini, tipično v parku.
 
 Osnovna razdelitev na podvrste je:
 
-- _slackline_: trak dolžine do 30 m s krajišči do višine človeka;
-- _longline_: trak dolžine več kot 30 m s krajišči do nekaj metrov nad tlemi;
-- _rodeo_: povsem nenapet trak z visokimi krajišči (do nekaj metrov) in velikim povesom;
-- _trickline_: izvajanje trikov (skokov, premetov) na zelo napetem in elastičnem traku;
-- *nadvodnica* (_waterline_): trak, napet (nizko) nad vodo;
-- _midline_: trak, postavljen tako visoko, da se je potrebno varovati z visom ampak dovolj nizko, da bi v primeru padca na [pomožni trak](/pomozni-trak) sigurno udarili ob tla.
-- *[visokica](/visokica)* (_highline_): trak, postavljen dovolj visoko, da bi bil nezavarovan padec z njega usoden in je zato potrebno varovanje z [visom](/vis). Ta podvrsta je predmet tega priročnika.
+* _slackline_: trak dolžine do 30 m s krajišči do višine človeka;
+* _longline_: trak dolžine več kot 30 m s krajišči do nekaj metrov nad tlemi;
+* _rodeo_: povsem nenapet trak z visokimi krajišči (do nekaj metrov) in velikim povesom;
+* _trickline_: izvajanje trikov (skokov, premetov) na zelo napetem in elastičnem traku;
+* _nadvodnica_ (_waterline_): trak, napet (nizko) nad vodo;
+* _midline_: trak, postavljen tako visoko, da se je potrebno varovati z visom ampak dovolj nizko, da bi v primeru padca na [pomožni trak](pomozni-trak) sigurno udarili ob tla.
+* _[visokica](visokica)_ (_highline_): trak, postavljen dovolj visoko, da bi bil nezavarovan padec z njega usoden in je zato potrebno varovanje z [visom](vis). Ta podvrsta je predmet tega priročnika.
+

--- a/src/wiki/slovar.md
+++ b/src/wiki/slovar.md
@@ -1,109 +1,84 @@
 # Slovar
 
-Slovensko visokovalsko izrazje je v aktivnem nastajanju. Ker si visokovanje
-nekatere koncepte ter kose opreme deli z drugimi dejavnostmi, poskušamo pri
-prevajanju najprej poiskati že obstoječe izraze. Slovenske ustreznice za opremo
-lahko na primer pogosto poberemo iz alpinizma ali navtike (primer: _vponka_,
-_škopec_). Če prevoda na ta način ne najdemo, poskušamo izraz prevesti po
-smislu - pri opremi se, na primer, vprašamo, kaj z njo počnemo oziroma kakemu
-namenu služi (primer: _webgrip_ -> _primež_). Naivnemu dobesednemu prevajanju
-fraz se poskušamo kar se da ogniti, saj pogosto vodi do izrazov, ki v
-slovenščini delujejo nenaravno (primer: _soft release_ -> _mehki izpust...?_).
-Če res ne najdemo druge možnosti, si v skrajnem primeru novo besedo izmislimo
-(npr. _leash_ -> _vis_).
+Slovensko visokovalsko izrazje je v aktivnem nastajanju. Ker si visokovanje nekatere koncepte ter kose opreme deli z drugimi dejavnostmi, poskušamo pri prevajanju najprej poiskati že obstoječe izraze. Slovenske ustreznice za opremo lahko na primer pogosto poberemo iz alpinizma ali navtike (primer: _vponka_, _škopec_). Če prevoda na ta način ne najdemo, poskušamo izraz prevesti po smislu – pri opremi se, na primer, vprašamo, kaj z njo počnemo oziroma kakemu namenu služi (primer: _webgrip_ -> _primež_). Naivnemu dobesednemu prevajanju fraz se poskušamo kar se da ogniti, saj pogosto vodi do izrazov, ki v slovenščini delujejo nenaravno (primer: _soft release_ -> _mehki izpust...?_). Če res ne najdemo druge možnosti, si v skrajnem primeru novo besedo izmislimo (npr. _leash_ -> _vis_).
 
-V spodnji tabeli so zbrani prevodi angleških izrazov v slovenske. Nekatere
-besede (npr. LineGrip, HangOver) so trgovske znamke, ki so prešle v splošno
-uporabo, ker je bil izdelek prvi svoje vrste na trgu. Ti izrazi se s širjenjem
-ponudbe na trgu počasi nadomeščajo z bolj splošnimi, npr. _webgrip_ kot krovni
-izraz za LineGrip, Snatch in podobne izdelke. Zaradi pogoste uporabe imajo
-takšni izrazi svoj vnos v slovarju, vendar bralca zgolj preusmerijo na bolj
-splošen izraz.
+V spodnji tabeli so zbrani prevodi angleških izrazov v slovenske. Nekatere besede (npr. LineGrip, HangOver) so trgovske znamke, ki so prešle v splošno uporabo, ker je bil izdelek prvi svoje vrste na trgu. Ti izrazi se s širjenjem ponudbe na trgu počasi nadomeščajo z bolj splošnimi, npr. _webgrip_ kot krovni izraz za LineGrip, Snatch in podobne izdelke. Zaradi pogoste uporabe imajo takšni izrazi svoj vnos v slovarju, vendar bralca zgolj preusmerijo na bolj splošen izraz.
 
 ---
 
 | angleški izraz                  | slovenski izraz                                               |
 | ------------------------------- | ------------------------------------------------------------- |
-| A-frame                         | [A-okvir](/a-okvir)                                           |
-| abrasion                        | [abrazija](/abrazija)                                         |
-| anchor                          | [sidrišče](/sidrisce)                                         |
+| A-frame                         | [A-okvir](a-okvir)                                           |
+| abrasion                        | [abrazija](abrazija)                                         |
+| anchor                          | [sidrišče](sidrisce)                                         |
 | backup                          | rezerva                                                       |
-| backup (webbing)                | [pomožni trak](/pomozni-trak)                                 |
-| big fucking knot (BFK)          | [jebeno velik vozel](/jebeno-velik-vozel)                     |
-| bowline                         | [najlonski vozel](/najlonski-vozel)                           |
-| carabiner                       | [vponka](/vponka)                                             |
+| backup (webbing)                | [pomožni trak](pomozni-trak)                                 |
+| big fucking knot (BFK)          | [jebeno velik vozel](jebeno-velik-vozel)                     |
+| bowline                         | [najlonski vozel](najlonski-vozel)                           |
+| carabiner                       | [vponka](vponka)                                             |
 | carabiner pulley                | glej _lineslide_                                              |
-| cascade failure                 | [verižna odpoved](/verizna-odpoved)                           |
-| clove hitch                     | [bičev vozel](/bicev-vozel)                                   |
-| Chongo mount                    | [vstajanje](/vstajanje) na Chongo                             |
-| delta quicklink                 | [deltasti člen](/deltasti-clen)                               |
-| drop-knee mount                 | [vstajanje](/vstajanje) s spuščenim kolenom                   |
-| elongation                      | [raztezek](/raztezek)                                         |
-| figure eight knot               | [osmica](/osmica)                                             |
-| Frost knot                      | [Frostov vozel](/frostov-vozel)                               |
-| girth hitch                     | [kavbojski vozel](/kavbojski-vozel)                           |
+| cascade failure                 | [verižna odpoved](verizna-odpoved)                           |
+| clove hitch                     | [bičev vozel](bicev-vozel)                                   |
+| Chongo mount                    | [vstajanje](vstajanje) na Chongo                             |
+| delta quicklink                 | [deltasti člen](deltasti-clen)                               |
+| drop-knee mount                 | [vstajanje](vstajanje) s spuščenim kolenom                   |
+| elongation                      | [raztezek](raztezek)                                         |
+| figure eight knot               | [osmica](osmica)                                             |
+| Frost knot                      | [Frostov vozel](frostov-vozel)                               |
+| girth hitch                     | [kavbojski vozel](kavbojski-vozel)                           |
 | HangOver (pulley)               | glej _carabiner pulley_                                       |
-| highline                        | [visokica](/visokica)                                         |
+| highline                        | [visokica](visokica)                                         |
 | highliner                       | visokovalec / visokovalka                                     |
 | highlining                      | visokovanje                                                   |
-| leash                           | [vis](/vis)                                                   |
+| leash                           | [vis](vis)                                                   |
 | LineGrip                        | glej _webgrip_                                                |
-| linelocker / lineslide          | [maček](/macek)                                               |
+| linelocker / lineslide          | [maček](macek)                                               |
 | loop                            | zanka                                                         |
 | connection                      | konekcija                                                     |
-| master point                    | [skupna točka](/skupna-tocka)                                 |
-| main line                       | [glavni trak](/glavni-trak)                                   |
-| mechanical advantage            | [mehanska prednost](/mehanska-prednost)                       |
+| master point                    | [skupna točka](skupna-tocka)                                 |
+| main line                       | [glavni trak](glavni-trak)                                   |
+| mechanical advantage            | [mehanska prednost](mehanska-prednost)                       |
 | midline                         | ?                                                             |
-| minimum breaking strength (MBS) | [minimalna porušna sila](/minimalna-porusna-sila)             |
-| multiplier                      | [množilnik](/mnozilnik)                                       |
-| padding                         | [podloga](/podloga)                                           |
-| pulley                          | [škripec](/skripec)                                           |
-| pulley system                   | [škripčevje](/napenjalni-sistem)                              |
-| quicklink                       | [ovalni člen](/ovalni-clen)                                   |
-| redundancy                      | [redundanca](/redundanca)                                     |
-| rigging                         | [postavljanje](/postavljanje)                                 |
+| minimum breaking strength (MBS) | [minimalna porušna sila](minimalna-porusna-sila)             |
+| multiplier                      | [množilnik](mnozilnik)                                       |
+| padding                         | [podloga](podloga)                                           |
+| pulley                          | [škripec](skripec)                                           |
+| pulley system                   | [škripčevje](napenjalni-sistem)                              |
+| quicklink                       | [ovalni člen](ovalni-clen)                                   |
+| redundancy                      | [redundanca](redundanca)                                     |
+| rigging                         | [postavljanje](postavljanje)                                 |
 | Rollex                          | glej _carabiner pulley_                                       |
-| safety ratio                    | [varnostno razmerje](/varnostno-razmerje)                     |
-| segmented line                  | [segmentiran](/segmentiranje) trak                            |
-| sewn loop                       | [šivana zanka](/sivana-zanka)                                 |
-| sit-start                       | [vstajanje](/vstajanje) iz sede                               |
-| slackline                       | [slackline](/slackline)                                       |
-| shackle                         | [škopec](/skopec)                                             |
-| sling                           | [neskončna zanka](/neskoncna-zanka)                           |
-| soft release                    | [popuščalka](/popuscalka)                                     |
-| soft shackle                    | [vrvni škopec](/vrvni-skopec)                                 |
-| spanset                         | [tovorna zanka](/tovorna-zanka)                               |
-| static side                     | [statična stran](/staticna-stran)                             |
-| tagline                         | [pilotna vrv](/pilotna-vrv)                                   |
-| tension                         | [napetost](/napetost)                                         |
-| tensioning                      | [napenjanje](/napenjanje)                                     |
-| tensioning side                 | [napenjalna stran](/napenjalna-stran)                         |
-| tensioning system               | [napenjalni sistem](/napenjalni-sistem)                       |
-| thimble                         | [podložka](/podlozka)                                         |
-| triloading                      | [trosmerna obremenitev](/trosmerna-obremenitev)               |
-| webbing                         | [trak](/trak)                                                 |
-| webgrip                         | [primež](/primez)                                             |
-| weblock                         | [banana](/banana)                                             |
-| working load limit (WLL)        | [največja delovna obremenitev](/najvecja-delovna-obremenitev) |
+| safety ratio                    | [varnostno razmerje](varnostno-razmerje)                     |
+| segmented line                  | [segmentiran](segmentiranje) trak                            |
+| sewn loop                       | [šivana zanka](sivana-zanka)                                 |
+| sit-start                       | [vstajanje](vstajanje) iz sede                               |
+| slackline                       | [slackline](slackline)                                       |
+| shackle                         | [škopec](skopec)                                             |
+| sling                           | [neskončna zanka](neskoncna-zanka)                           |
+| soft release                    | [popuščalka](popuscalka)                                     |
+| soft shackle                    | [vrvni škopec](vrvni-skopec)                                 |
+| spanset                         | [tovorna zanka](tovorna-zanka)                               |
+| static side                     | [statična stran](staticna-stran)                             |
+| tagline                         | [pilotna vrv](pilotna-vrv)                                   |
+| tension                         | [napetost](napetost)                                         |
+| tensioning                      | [napenjanje](napenjanje)                                     |
+| tensioning side                 | [napenjalna stran](napenjalna-stran)                         |
+| tensioning system               | [napenjalni sistem](napenjalni-sistem)                       |
+| thimble                         | [podložka](podlozka)                                         |
+| triloading                      | [trosmerna obremenitev](trosmerna-obremenitev)               |
+| webbing                         | [trak](trak)                                                 |
+| webgrip                         | [primež](primez)                                             |
+| weblock                         | [banana](banana)                                             |
+| working load limit (WLL)        | [največja delovna obremenitev](najvecja-delovna-obremenitev) |
 
 ---
 
 ## Žargonski izrazi
 
-V visokovalski praksi se, kot v vsakem specializiranem okolju, uporabljajo tudi
-žargonski izrazi, ki so pogosto prevzeti iz žargona drugih dejavnosti,
-največkrat plezalstva. Čeprav njihova uporaba ni priporočena, saj imamo zanje
-povsem klene slovenske ustreznice, jih prej ali slej sreča vsak visokovalec,
-zato je smiselno, da je del slovarja posvečen tudi njim. Zaradi predpostavke
-splošnega znanja angleščine spodnja tabela ne vključuje angleških besed, ki so
-samo prilagojene slovenski izgovorjavi (npr. "šekl" - angleško _shackle_, torej
-[škopec](/skopec)), temveč le tiste, ki so bodisi zares samostojni žargonski
-izrazi bodisi izvirajo iz kakega drugega jezika, katerega znanja pri poslušalcih
-ne moremo nujno predpostaviti (največkrat nemščina).
+V visokovalski praksi se, kot v vsakem specializiranem okolju, uporabljajo tudi žargonski izrazi, ki so pogosto prevzeti iz žargona drugih dejavnosti, največkrat plezalstva. Čeprav njihova uporaba ni priporočena, saj imamo zanje povsem klene slovenske ustreznice, jih prej ali slej sreča vsak visokovalec, zato je smiselno, da je del slovarja posvečen tudi njim. Zaradi predpostavke splošnega znanja angleščine spodnja tabela ne vključuje angleških besed, ki so samo prilagojene slovenski izgovorjavi (npr. "šekl" – angleško _shackle_, torej [škopec](skopec)), temveč le tiste, ki so bodisi zares samostojni žargonski izrazi bodisi izvirajo iz kakega drugega jezika, katerega znanja pri poslušalcih ne moremo nujno predpostaviti (največkrat nemščina).
 
 | žargonski izraz | slovenska ustreznica                |
 | --------------- | ----------------------------------- |
-| gurtna          | [trak](/trak)                       |
-| šlinga          | [neskončna zanka](/neskoncna-zanka) |
-| štant           | [sidrišče](/sidrisce)               |
+| gurtna          | [trak](trak)                       |
+| šlinga          | [neskončna zanka](neskoncna-zanka) |
+| štant           | [sidrišče](sidrisce)               |

--- a/src/wiki/spletni-viri.md
+++ b/src/wiki/spletni-viri.md
@@ -1,16 +1,11 @@
 # Spletni viri
 
-[HowNOT2](https://www.youtube.com/c/HowNOT2): YouTube kanal z zakladnico videov
-na temo visokovanja: osnove, testi opreme, eksperimenti ...
+[HowNOT2](https://www.youtube.com/c/HowNOT2): YouTube kanal z zakladnico videov na temo visokovanja: osnove, testi opreme, eksperimenti ...
 
-[slackline.com](https://www.slackline.com/): Spletna stran projekta
-HowNOTtoHIGHLINE: spletne knjige, rezultati testiranja opreme, povezave na
-visokovalsko skupnost. Verjetno osrednja spletna stran za visokovanje.
+[slackline.com](https://www.slackline.com/): Spletna stran projekta HowNOTtoHIGHLINE: spletne knjige, rezultati testiranja opreme, povezave na visokovalsko skupnost. Verjetno osrednja spletna stran za visokovanje.
 
 [ISA](https://www.slacklineinternational.org): Mednarodna slacklinerska zveza.
 
-[SlackDB](https://slackdb.com/): Obširna zbirka podatkov o opremi za slackline
-in visokovanje (trakovi, banane, primeži itd.).
+[SlackDB](https://slackdb.com/): Obširna zbirka podatkov o opremi za slackline in visokovanje (trakovi, banane, primeži itd.).
 
-[SlackMap](https://slackmap.com): Zemljevid sveta z vrisanimi relacijami, kjer
-je mogoče postaviti trakove.
+[SlackMap](https://slackmap.com): Zemljevid sveta z vrisanimi relacijami, kjer je mogoče postaviti trakove.

--- a/src/wiki/start.md
+++ b/src/wiki/start.md
@@ -1,34 +1,17 @@
 # Začetna stran
 
-Dobrodošel, dobrodošla na slovenskem visokovalskem priročniku. Poslanstvo te
-spletne strani je nudenje informacij, povezanih z [visokicami](/visokica)
-(_highline_) in visokovanjem, v slovenskem jeziku in za slovenski prostor.
-Vsebino urejajo člani slovenske visokovalske skupnosti.
+Dobrodošel, dobrodošla na slovenskem visokovalskem priročniku. Poslanstvo te spletne strani je nudenje informacij, povezanih z [visokicami](visokica) (_highline_) in visokovanjem, v slovenskem jeziku in za slovenski prostor. Vsebino urejajo člani slovenske visokovalske skupnosti.
 
 ## Kaj je visokovanje?
 
-Visokovanje ena od različic hoje po napetem traku ([slackline](/slackline)), pri
-kateri je trak postavljen na veliki višini - od vsaj nekaj deset metrov nad
-tlemi, pa tudi do več sto. Takšna postavitev omogoča povsem svojevrstno
-izkušnjo, a obenem zahteva posebno opremo, znanje ter pristope, ki zagotavljajo,
-da je podvig tudi varen.
+Visokovanje ena od različic hoje po napetem traku ([slackline](slackline)), pri kateri je trak postavljen na veliki višini – od vsaj nekaj deset metrov nad tlemi, pa tudi do več sto. Takšna postavitev omogoča povsem svojevrstno izkušnjo, a obenem zahteva posebno opremo, znanje ter pristope, ki zagotavljajo, da je podvig tudi varen.
 
 ![Andrej Bvaščeva](images/andrej-bvasceva.jpg)
 
 ## Za začetnike in začetnice
 
-- POMEMBNO: Če te zanima visokovanje, se tega nikakor ne lotevaj sam, saj je
-  vsaka napaka lahko usodna! Visokovanje je sicer precej varen šport, a le,
-  kadar je oprema postavljena in preverjena s strani izkušenih visokovalcev.
-  Predlagamo, se o visokovanju najprej poučiš s pomočjo tega priročnika in
-  drugih [spletnih virov](/spletni-viri), nato pa se pridružiš kaki izmed
-  [visokovalskih skupin](/skupnost). Za obširnejše informacije si oglej stran
-  [za začetnike](/za-zacetnike).
+**POMEMBNO:** Če te zanima visokovanje, se tega nikakor ne lotevaj sam, saj je vsaka napaka lahko usodna! Visokovanje je sicer precej varen šport, a le, kadar je oprema postavljena in preverjena s strani izkušenih visokovalcev. Predlagamo, se o visokovanju najprej poučiš s pomočjo tega priročnika in drugih [spletnih virov](spletni-viri), nato pa se pridružiš kaki izmed [visokovalskih skupin](skupnost). Za obširnejše informacije si oglej stran [za začetnike](za-zacetnike).
 
 ## Izrazje
 
-V priročniku se trudimo uporabljati slovenske izraze, četudi to pomeni, da jih
-moramo na novo izumiti. Visokovanje je dokaj nov šport, zato mnoge zanj
-specifične besede še nimajo slovenskih ustreznic. Na voljo je [slovar](/slovar),
-ki trenutno služi tudi kot najbolj priročno izhodišče za raziskovanje te spletne
-strani.
+V priročniku se trudimo uporabljati slovenske izraze, četudi to pomeni, da jih moramo na novo izumiti. Visokovanje je dokaj nov šport, zato mnoge zanj specifične besede še nimajo slovenskih ustreznic. Na voljo je [slovar](slovar), ki trenutno služi tudi kot najbolj priročno izhodišče za raziskovanje te spletne strani.

--- a/src/wiki/staticna-stran.md
+++ b/src/wiki/staticna-stran.md
@@ -1,10 +1,3 @@
 # Statična stran
 
-_Statična stran_ visokice je krajišče, na katerem je visokica statično vpeta v
-[sidrišče](/sidrisce). Za vpetje [traku](/trak) se lahko uporabi bodisi
-[banano](/banana) bodisi [šivano zanko](/sivana-zanka). Na tem mestu je
-nameščena tudi [popuščalka](/popuscalka), s katero po končani uporabi popustimo
-[napetost](/napetost) v traku, da ga lahko podremo. Statična stran je običajno
-(a ne nujno) slabše dostopna in se do nje dostopa le ob
-[postavljanju](/postavljanje) in podiranju. Druga stran visokice je
-[napenjalna stran](/napenjalna-stran).
+_Statična stran_ visokice je krajišče, na katerem je visokica statično vpeta v [sidrišče](sidrisce). Za vpetje [traku](trak) se lahko uporabi bodisi [banano](banana) bodisi [šivano zanko](sivana-zanka). Na tem mestu je nameščena tudi [popuščalka](popuscalka), s katero po končani uporabi popustimo [napetost](napetost) v traku, da ga lahko podremo. Statična stran je običajno (a ne nujno) slabše dostopna in se do nje dostopa le ob [postavljanju](postavljanje) in podiranju. Druga stran visokice je [napenjalna stran](napenjalna-stran).

--- a/src/wiki/tovorna-zanka.md
+++ b/src/wiki/tovorna-zanka.md
@@ -1,21 +1,5 @@
 # Tovorna zanka
 
-_Tovorna zanka_ je vrsta [neskončne zanke](/neskoncna-zanka), ki je namenjena za
-tovorno uporabo. Izdelana je iz mnogo ovojev tanke vrvi, vstavljene v širok
-cevast trak. Tovorne zanke odlikujejo njihova zanesljivost, dobra nosilnost in
-velika trpežnost, zato so nepogrešljive na [sidriščih](/sidrisce)
-[slacklinov](/slackline) in [visokic](/visokica).
+_Tovorna zanka_ je vrsta [neskončne zanke](neskoncna-zanka), ki je namenjena za tovorno uporabo. Izdelana je iz mnogo ovojev tanke vrvi, vstavljene v širok cevast trak. Tovorne zanke odlikujejo njihova zanesljivost, dobra nosilnost in velika trpežnost, zato so nepogrešljive na [sidriščih](sidrisce) [slacklinov](slackline) in [visokic](visokica).
 
-Tovorne zanke so standardiziran izdelek, ki ga lahko kupimo v trgovinah s
-tehničnim materialom. Po nosilnosti so razdeljene v razrede in so glede na
-razred tudi barvno kodirane: vijolične zanke imajo
-[največjo delovno obremenitev](/najvecja-delovna-obremenitev) eno tono, zelene
-zanke dve toni in rumene zanke tri tone. Ker se sile na [sidriščih](/sidrisce)
-visokic nikoli ne povzpnejo preko 10 kN, v visokovanju srečujemo praktično
-izključno vijolične zanke. Prav tako pa imajo vse te industrijske zanke
-[varnostno razmerje](/varnostno-razmerje) 7, kar pomeni, da ima vijolična zanka
-z največjo dovoljeno obremenitvijo 10 kN
-[minimalno porušno silo](/minimalna-porusna-sila) približno 70 kN. Standardne
-dolžine zank se gibljejo v območju med 1 in 5 m, pri čemer se dolžina nanaša na
-iztegnjeno zanko in ne na dolžino njenega oboda. Tovorne zanke lahko po potrebi
-sestavljamo v daljše nize s [kavbojskim vozlom](/kavbojski-vozel).
+Tovorne zanke so standardiziran izdelek, ki ga lahko kupimo v trgovinah s tehničnim materialom. Po nosilnosti so razdeljene v razrede in so glede na razred tudi barvno kodirane: vijolične zanke imajo [največjo delovno obremenitev](najvecja-delovna-obremenitev) eno tono, zelene zanke dve toni in rumene zanke tri tone. Ker se sile na [sidriščih](sidrisce) visokic nikoli ne povzpnejo preko 10 kN, v visokovanju srečujemo praktično izključno vijolične zanke. Prav tako pa imajo vse te industrijske zanke [varnostno razmerje](varnostno-razmerje) 7, kar pomeni, da ima vijolična zanka z največjo dovoljeno obremenitvijo 10 kN [minimalno porušno silo](minimalna-porusna-sila) približno 70 kN. Standardne dolžine zank se gibljejo v območju med 1 in 5 m, pri čemer se dolžina nanaša na iztegnjeno zanko in ne na dolžino njenega oboda. Tovorne zanke lahko po potrebi sestavljamo v daljše nize s [kavbojskim vozlom](kavbojski-vozel).

--- a/src/wiki/trak.md
+++ b/src/wiki/trak.md
@@ -1,83 +1,48 @@
 # Trak
 
-Elastičen tekstilni _trak_ je osrednji rekvizit pri vseh različicah
-[slacklina](/slackline). Prvotno se je za slackline uporabljal plezalski
-najlonski trak širine 2,5 cm, a z širšim razmahom tega športa se je na tržišču
-pojavilo še mnogo drugačnih trakov z različnimi lastnostmi. Izbira traku tako je
-odvisna od predvidene dolžine relacij, želene elastičnosti traku, njegove
-nosilnosti, vrste uporabe (hoja, izvajanje trikov), odpornosti na okoljske
-vplive ter drugih dejavnikov.
+Elastičen tekstilni _trak_ je osrednji rekvizit pri vseh različicah [slacklina](slackline). Prvotno se je za slackline uporabljal plezalski najlonski trak širine 2,5 cm, a z širšim razmahom tega športa se je na tržišču pojavilo še mnogo drugačnih trakov z različnimi lastnostmi. Izbira traku tako je odvisna od predvidene dolžine relacij, želene elastičnosti traku, njegove nosilnosti, vrste uporabe (hoja, izvajanje trikov), odpornosti na okoljske vplive ter drugih dejavnikov.
 
 ## Vrste
 
 ![Trak](images/trak.jpg)
 
-Trakovi se med seboj v grobem ločijo po materialu, širini in načinu pletenja. Te
-značilnosti močno vplivajo na lastnosti traku in ga delajo bolj ali manj
-primernega za specifične podkategorije slacklina.
+Trakovi se med seboj v grobem ločijo po materialu, širini in načinu pletenja. Te značilnosti močno vplivajo na lastnosti traku in ga delajo bolj ali manj primernega za specifične podkategorije slacklina.
 
 ### Material
 
 Najpogosteje se za izdelavo traku uporabljajo naslednji materiali:
 
-- poliamid (najlon) – zelo elastični in mehki trakovi;
-- poliester – trakovi z manjšo elastičnostjo, primerni za večje razdalje;
-- [UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (Dyneema) – trakovi z zelo
-  majhno elastičnostjo, za ekstremne razdalje.
+* poliamid (najlon) – zelo elastični in mehki trakovi;
+* poliester – trakovi z manjšo elastičnostjo, primerni za večje razdalje;
+* [UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (Dyneema) – trakovi z zelo majhno elastičnostjo, za ekstremne razdalje.
 
-Sestava traku je lahko tudi kombinirana: tako imajo, na primer, nekateri trakovi
-za ekstremne razdalje sredico izdelano iz UHMWPE, plašč pa iz poliestra. Pri tem
-zunanja poliestrska plast dela trak udobnejši za hojo, hkrati pa ščiti nosilno
-sredico pred [abrazijo](/abrazija).
+Sestava traku je lahko tudi kombinirana: tako imajo, na primer, nekateri trakovi za ekstremne razdalje sredico izdelano iz UHMWPE, plašč pa iz poliestra. Pri tem zunanja poliestrska plast dela trak udobnejši za hojo, hkrati pa ščiti nosilno sredico pred [abrazijo](abrazija).
 
 ### Vrsta pletenja
 
 Tudi pri vrsti pletenja lahko trakove v grobem razdelimo v nekaj kategorij:
 
-- **Cevasti (tubularni) trakovi.** Ti so običajno izdelani iz poliamida. Zaradi
-  cevastega pletenja so takšni trakovi debelejši in imajo zaobljene robove, kar
-  jih dela prijetne za hojo.
-- **Ploski trakovi.** Tehnologija izdelava takšnih trakov je preprosta, zato so
-  precej pogosti in imajo ugodno ceno. Njihova slaba stran je, da so robovi
-  ostrejši, zlasti pri visokih [napetostih](/napetost).
-- **Večplastni trakovi.** Takšni trakovi so sestavljeni iz več medsebojno
-  prepletenih plasti, s čimer dosežemo kombinacijo več ugodnih karakteristik.
-  Eden najpogostejših ciljev je, da sredinska plast prevzame večino sile v
-  traku, medtem ko je zunanja plast pletena bolj ohlapno in zato tudi pri
-  višjih [napetostih](/napetost) ostane mehka, robovi pa zaobljeni. S tem dobimo
-  trak z zmerno elastičnostjo, ki pa je še vedno prijeten za hojo. Slabost
-  večplastnih trakov je njihova višja cena, saj je tehnologija njihove izdelave
-  zahtevnejša.
+* **Cevasti (tubularni) trakovi.** Ti so običajno izdelani iz poliamida. Zaradi cevastega pletenja so takšni trakovi debelejši in imajo zaobljene robove, kar jih dela prijetne za hojo.
+* **Ploski trakovi.** Tehnologija izdelava takšnih trakov je preprosta, zato so precej pogosti in imajo ugodno ceno. Njihova slaba stran je, da so robovi ostrejši, zlasti pri visokih [napetostih](napetost).
+* **Večplastni trakovi.** Takšni trakovi so sestavljeni iz več medsebojno prepletenih plasti, s čimer dosežemo kombinacijo več ugodnih karakteristik. Eden najpogostejših ciljev je, da sredinska plast prevzame večino sile v traku, medtem ko je zunanja plast pletena bolj ohlapno in zato tudi pri višjih [napetostih](napetost) ostane mehka, robovi pa zaobljeni. S tem dobimo trak z zmerno elastičnostjo, ki pa je še vedno prijeten za hojo. Slabost večplastnih trakov je njihova višja cena, saj je tehnologija njihove izdelave zahtevnejša.
 
 ### Širina
 
-Za slackline se najpogosteje uporabljajo trakovi širine 2,5 cm. Izjema so
-kratki, začetniški trakovi, ki so navadno širši (3,5 cm ali 5 cm) ter trakovi za
-izvajanje trikov, ki so široki 5 cm. Kljub splošno razširjenemu prepričanju
-začetnikov, da je hoja po širšem traku enostavnejša, širina traku na težavnost
-ne vpliva bistveno. Mnogi slacklinerji sčasoma pridejo celo do zaključka, da je
-klasičen 2,5-centimetrski trak pravzaprav prijetnejši za hojo. Razlog za uporabo
-širših trakov v začetniških kompletih je bržkone dejstvo, da lahko proizvajalci
-preprosto priložijo kar standardne tovorne 5-centimetrske napenjalne mehanizme.
+Za slackline se najpogosteje uporabljajo trakovi širine 2,5 cm. Izjema so kratki, začetniški trakovi, ki so navadno širši (3,5 cm ali 5 cm) ter trakovi za izvajanje trikov, ki so široki 5 cm. Kljub splošno razširjenemu prepričanju začetnikov, da je hoja po širšem traku enostavnejša, širina traku na težavnost ne vpliva bistveno. Mnogi slacklinerji sčasoma pridejo celo do zaključka, da je klasičen 2,5-centimetrski trak pravzaprav prijetnejši za hojo. Razlog za uporabo širših trakov v začetniških kompletih je bržkone dejstvo, da lahko proizvajalci preprosto priložijo kar standardne tovorne 5-centimetrske napenjalne mehanizme.
 
-Na [visokicah](/visokica) se skoraj izključno uporabljajo trakovi širine 2,5 cm,
-in za to širino je izdelana tudi vsa namenska oprema (npr. [banane](/banana)). V
-posebnih primerih - visokice, dolge kilometer ali več - se v zadnjem času
-uveljavlja uporaba celo ožjih trakov (med 1,7 in 2,5 cm), ker z njimi zmanjšamo
-obremenitve traku zaradi vetra.
+Na [visokicah](visokica) se skoraj izključno uporabljajo trakovi širine 2,5 cm, in za to širino je izdelana tudi vsa namenska oprema (npr. [banane](banana)). V posebnih primerih – visokice, dolge kilometer ali več – se v zadnjem času uveljavlja uporaba celo ožjih trakov (med 1,7 in 2,5 cm), ker z njimi zmanjšamo obremenitve traku zaradi vetra.
 
 ## Karakteristike
 
 Lastnosti trakov običajno opredelimo z navedbo naslednjih karakteristik:
 
-- material
-- vrsta pletenja
-- širina
-- debelina
-- masa (grami na meter traku)
-- [največja delovna obremenitev](/najvecja-delovna-obremenitev) (WLL)
-- [minimalna porušna sila](/minimalna-porusna-sila) (MBS)
-- [raztezek](/raztezek)
+* material
+* vrsta pletenja
+* širina
+* debelina
+* masa (grami na meter traku)
+* [največja delovna obremenitev](najvecja-delovna-obremenitev) (WLL)
+* [minimalna porušna sila](minimalna-porusna-sila) (MBS)
+* [raztezek](raztezek)
 
-Za uporabo na visokicah je standardna zahteva, da ima trak
-[minimalno porušno silo](/minimalna-porusna-sila) nad 25 kN.
+Za uporabo na visokicah je standardna zahteva, da ima trak [minimalno porušno silo](minimalna-porusna-sila) nad 25 kN.

--- a/src/wiki/trosmerna-obremenitev.md
+++ b/src/wiki/trosmerna-obremenitev.md
@@ -1,9 +1,3 @@
 # Trosmerna obremenitev
 
-_Trosmerna obremenitev_ je stanje, ko na vezni člen delujejo sile v treh
-različnih smereh. Tipičen primer takšne obremenitve je sidranje slacklina na
-[tovorno zanko](/tovorna-zanka), ovito okoli drevesa. Vsak konec tovorne zanke
-vleče vezni člen v svojo smer, tretjo smer pa prispeva sila napetega traku.
-Nekateri vezni členi (na primer [škopec](/skopec)) takšno obremenitev dobro
-prenašajo, drugi (na primer [vponka](/vponka)) pa ne, zato je v takih
-okoliščinah prava izbira veznega člena zelo pomembna.
+_Trosmerna obremenitev_ je stanje, ko na vezni člen delujejo sile v treh različnih smereh. Tipičen primer takšne obremenitve je sidranje slacklina na [tovorno zanko](tovorna-zanka), ovito okoli drevesa. Vsak konec tovorne zanke vleče vezni člen v svojo smer, tretjo smer pa prispeva sila napetega traku. Nekateri vezni členi (na primer [škopec](skopec)) takšno obremenitev dobro prenašajo, drugi (na primer [vponka](vponka)) pa ne, zato je v takih okoliščinah prava izbira veznega člena zelo pomembna.

--- a/src/wiki/varnostno-razmerje.md
+++ b/src/wiki/varnostno-razmerje.md
@@ -1,16 +1,5 @@
 # Varnostno razmerje
 
-_Varnostno razmerje_ je razmerje med
-[minimalno porušno silo](/minimalna-porusna-sila) kosa opreme ter ocenjeno
-največjo silo, ki ji je ta oprema podvržena pri uporabi. Višje ko je varnostno
-razmerje, manj verjetno je, da zaradi nepredvidenih dejavnikov pride do
-preobremenitve in odpovedi opreme. V praksi se pri snovanju sistemov vedno
-soočamo z neko mero nedoločenosti: s še tako temeljitim pregledom opreme namreč
-ne moremo vedno zaznati skritih napak ali poškodb, na zanesljivost pa vplivata
-tudi starost opreme ter specifične okoliščine uporabe. Z dovolj velikim
-varnostim razmerjem kompenziramo za takšne nedoločenosti.
+_Varnostno razmerje_ je razmerje med [minimalno porušno silo](minimalna-porusna-sila) kosa opreme ter ocenjeno največjo silo, ki ji je ta oprema podvržena pri uporabi. Višje ko je varnostno razmerje, manj verjetno je, da zaradi nepredvidenih dejavnikov pride do preobremenitve in odpovedi opreme. V praksi se pri snovanju sistemov vedno soočamo z neko mero nedoločenosti: s še tako temeljitim pregledom opreme namreč ne moremo vedno zaznati skritih napak ali poškodb, na zanesljivost pa vplivata tudi starost opreme ter specifične okoliščine uporabe. Z dovolj velikim varnostim razmerjem kompenziramo za takšne nedoločenosti.
 
-Izbira ustreznega varnostnega razmerja ni preprosta in je naposled vedno odvisna
-od stopnje tveganja, ki smo ga pripravljeni sprejeti. V vsaj osnovno orientacijo
-naj povemo, da za zelo dobro vrednost pri postavljanju [visokic](/visokica)
-velja varnostno razmerje 5.
+Izbira ustreznega varnostnega razmerja ni preprosta in je naposled vedno odvisna od stopnje tveganja, ki smo ga pripravljeni sprejeti. V vsaj osnovno orientacijo naj povemo, da za zelo dobro vrednost pri postavljanju [visokic](visokica) velja varnostno razmerje 5.

--- a/src/wiki/verizna-odpoved.md
+++ b/src/wiki/verizna-odpoved.md
@@ -1,12 +1,3 @@
 # Verižna odpoved
 
-_Verižna odpoved_ je dogodek, pri katerem odpoved ene komponente v sistemu
-povzroči preobremenitev ter posledično odpoved nadaljnjih. Takšen način
-porušenja je izredno nevaren, saj lahko usodno prizadene tudi na videz
-[redundantne](/redundanca) sisteme. Klasičen primer takšnega scenarija je
-odpoved enega od dveh sidriščnih vijakov v skali, ki sta z zanko povezana v
-[skupno točko](/skupna-tocka). Ob izpuljenju enega vijaka se zanka na mah
-raztegne in prenese celo obremenitev na drugi vijak. Pri tem je preostali vijak
-hipno izpostavljen močnemu sunku, ki lahko povzroči izpuljenje še tega. Pri
-zagotavljanju potrebne redundance je zato vedno treba misliti ne le na statične
-obremenitve ob potencialne odpovedi, temveč tudi na dinamične.
+_Verižna odpoved_ je dogodek, pri katerem odpoved ene komponente v sistemu povzroči preobremenitev ter posledično odpoved nadaljnjih. Takšen način porušenja je izredno nevaren, saj lahko usodno prizadene tudi na videz [redundantne](redundanca) sisteme. Klasičen primer takšnega scenarija je odpoved enega od dveh sidriščnih vijakov v skali, ki sta z zanko povezana v [skupno točko](skupna-tocka). Ob izpuljenju enega vijaka se zanka na mah raztegne in prenese celo obremenitev na drugi vijak. Pri tem je preostali vijak hipno izpostavljen močnemu sunku, ki lahko povzroči izpuljenje še tega. Pri zagotavljanju potrebne redundance je zato vedno treba misliti ne le na statične obremenitve ob potencialne odpovedi, temveč tudi na dinamične.

--- a/src/wiki/vis.md
+++ b/src/wiki/vis.md
@@ -1,37 +1,9 @@
 # Vis
 
-_Vis_ je varnostna vez, s katero je visokovalec povezan z [visokico](/visokica)
-in ki ga zadrži v primeru padca. Na enem koncu je vis privezan na kovinska
-obroča, ki drsita preko [glavnega](/glavni-trak) in [pomožnega](/pomozni-trak)
-traku, na drugem pa na plezalni pas visokovalca. Vis je običajno izdelan iz
-vrvi, vdete skozi cevasti [trak](/trak). Vloga slednjega je predvsem
-preprečevanje [abrazije](/abrazija) ter izboljšanje ergonomičnosti, ne služi pa
-kot varnostni element. Vis je zato, poleg plezalnega pasu, edini
-[neredundantni](/redundanca) del visokice.
+_Vis_ je varnostna vez, s katero je visokovalec povezan z [visokico](visokica) in ki ga zadrži v primeru padca. Na enem koncu je vis privezan na kovinska obroča, ki drsita preko [glavnega](glavni-trak) in [pomožnega](pomozni-trak) traku, na drugem pa na plezalni pas visokovalca. Vis je običajno izdelan iz vrvi, vdete skozi cevasti [trak](trak). Vloga slednjega je predvsem preprečevanje [abrazije](abrazija) ter izboljšanje ergonomičnosti, ne služi pa kot varnostni element. Vis je zato, poleg plezalnega pasu, edini [neredundantni](redundanca) del visokice.
 
-Za privezovanje na vis veljajo podobna pravila kot za privezovanje na plezalno
-vrvi. Za vozel se skoraj izključno uporablja vpletena [osmica](/osmica).
-Pomembno je, da je vis vedno speljan skozi obe glavni zanki na plezalnem pasu in
-_ne_ skozi manevrsko zanko. Primerno dolžino visa lahko približno določimo tako,
-da ga prevlečemo skozi zanki na pasu, ga napnemo in iztegnemo nogo proti
-kovinskim obročem na drugem koncu. Pri tem mora med stopalom in obroči ostati
-med 10 in 20 cm prostora. Prekratek vis prepreči, da bi se pri hoji lahko dovolj
-vzravnali, predolg vis pa poveča nevarnost ovitja okoli okončin med padcem ter
-povzroči, da se je po padcu težje [dvigniti](/dvig-na-trak) nazaj na trak.
+Za privezovanje na vis veljajo podobna pravila kot za privezovanje na plezalno vrvi. Za vozel se skoraj izključno uporablja vpletena [osmica](osmica). Pomembno je, da je vis vedno speljan skozi obe glavni zanki na plezalnem pasu in _ne_ skozi manevrsko zanko. Primerno dolžino visa lahko približno določimo tako, da ga prevlečemo skozi zanki na pasu, ga napnemo in iztegnemo nogo proti kovinskim obročem na drugem koncu. Pri tem mora med stopalom in obroči ostati med 10 in 20 cm prostora. Prekratek vis prepreči, da bi se pri hoji lahko dovolj vzravnali, predolg vis pa poveča nevarnost ovitja okoli okončin med padcem ter povzroči, da se je po padcu težje [dvigniti](dvig-na-trak) nazaj na trak.
 
-Pri hoji se vis praviloma vodi med nogami. Ker se je treba pri padcu čim bolj
-izogniti stiku z njim, je tehnika padanja na visokicah precej drugačna kot pri
-padanju na nizkih trakovih brez varovanja. Čeprav sprva neintuitivna, je najbolj
-zanesljiva in varna tehnika skoka - oziroma bolje rečeno _prevrnjenja_ - na
-glavo. Pri tem je treba noge čim dlje držati iztegnjene in v stiku s trakom, da
-ga med padcem odrinemo od sebe.
+Pri hoji se vis praviloma vodi med nogami. Ker se je treba pri padcu čim bolj izogniti stiku z njim, je tehnika padanja na visokicah precej drugačna kot pri padanju na nizkih trakovih brez varovanja. Čeprav sprva neintuitivna, je najbolj zanesljiva in varna tehnika skoka – oziroma bolje rečeno _prevrnjenja_ – na glavo. Pri tem je treba noge čim dlje držati iztegnjene in v stiku s trakom, da ga med padcem odrinemo od sebe.
 
-Zaradi bližine visokovalcu je vis element, ki povzroči največ visokovalskih
-poškodb. Najpogosteje se pripetijo tako, da se vis ob padanju oblikuje v ohlapno
-zanko, ki se ovije okoli visokovalčeve okončine ali prsta. Ko vis prevzame težo,
-se zanka zadrgne in povzroči odrgnino, izpah, zlom ali celo amputacijo. Za
-preprečevanje poškodb je zato pomembno, da kljubujemo naravnemu refleksu in se v
-začetni fazi padca _ne_ prijemamo za vis. Možnost oblikovanja nevarnih zank se
-močno poveča, če je vis zasukan okoli svoje osi, zato je izredno pomembno, da ga
-po padcih preverimo in po potrebi odsukamo. Pri tem je na večini visov v pomoč
-barvni vzorec ali tanka reliefna črta, ki poteka vzdolž visa.
+Zaradi bližine visokovalcu je vis element, ki povzroči največ visokovalskih poškodb. Najpogosteje se pripetijo tako, da se vis ob padanju oblikuje v ohlapno zanko, ki se ovije okoli visokovalčeve okončine ali prsta. Ko vis prevzame težo, se zanka zadrgne in povzroči odrgnino, izpah, zlom ali celo amputacijo. Za preprečevanje poškodb je zato pomembno, da kljubujemo naravnemu refleksu in se v začetni fazi padca _ne_ prijemamo za vis. Možnost oblikovanja nevarnih zank se močno poveča, če je vis zasukan okoli svoje osi, zato je izredno pomembno, da ga po padcih preverimo in po potrebi odsukamo. Pri tem je na večini visov v pomoč barvni vzorec ali tanka reliefna črta, ki poteka vzdolž visa.

--- a/src/wiki/visokica.md
+++ b/src/wiki/visokica.md
@@ -1,48 +1,17 @@
 # Visokica
 
-_Visokica_ je [slackline](/slackline), napet na dovoljšnji višini, da bi bil
-nezavarovan padec z njega usoden in je zato potrebno varovanje z [visom](/vis)
-ter uporaba posebnih tehnik pri [postavljanju](/postavljanje). Čeprav velika
-višina s seboj prinaša nekatere nevarnosti, je s primernim znanjem in tehniko
-mogoče tveganje zelo omejiti, in v takem primeru je visokovanje v mnogo pogledih
-celo varnejše od slacklina v parku, saj je povsem odstranjena sicer znatna
-možnost poškodb ob padcu na tla. Visokice se tipično postavlja na zračnih,
-razglednih mestih, zaradi česar ima visokovanje poleg športne tudi precejšnjo
-estetsko komponento.
+_Visokica_ je [slackline](slackline), napet na dovoljšnji višini, da bi bil nezavarovan padec z njega usoden in je zato potrebno varovanje z [visom](vis) ter uporaba posebnih tehnik pri [postavljanju](postavljanje). Čeprav velika višina s seboj prinaša nekatere nevarnosti, je s primernim znanjem in tehniko mogoče tveganje zelo omejiti, in v takem primeru je visokovanje v mnogo pogledih celo varnejše od slacklina v parku, saj je povsem odstranjena sicer znatna možnost poškodb ob padcu na tla. Visokice se tipično postavlja na zračnih, razglednih mestih, zaradi česar ima visokovanje poleg športne tudi precejšnjo estetsko komponento.
 
-Hoja po visokici zaradi oddaljenosti vseh referenčnih točk in odsotnosti tal
-zahteva specifična znanja in sposobnosti: izostren čut za ravnotežje, sposobnost
-[dviga na trak](/dvig-na-trak) ter [vstajanja](/vstajanje) iz sedečega položaja.
-Velika dojeta izpostavljenost poleg tega dela podvig ne le fizično, temveč tudi
-psihično zahteven. Priporočeno je, da se zato visokovanja lotevajo le osebe, ki
-so že dovolj vešče na običajnem [slacklinu](/slackline). Nekaj osnovnih vodil je
-zbranih na strani [za začetnike](/za-zacetnike).
+Hoja po visokici zaradi oddaljenosti vseh referenčnih točk in odsotnosti tal zahteva specifična znanja in sposobnosti: izostren čut za ravnotežje, sposobnost [dviga na trak](dvig-na-trak) ter [vstajanja](vstajanje) iz sedečega položaja. Velika dojeta izpostavljenost poleg tega dela podvig ne le fizično, temveč tudi psihično zahteven. Priporočeno je, da se zato visokovanja lotevajo le osebe, ki so že dovolj vešče na običajnem [slacklinu](slackline). Nekaj osnovnih vodil je zbranih na strani [za začetnike](za-zacetnike).
 
 ## Zgradba
 
-Visokica je sestavljena iz dveh [sidrišč](/sidrisce), med katerima je razpet
-[trak](/trak). Za sidrišča se navadno uporabi močna drevesa ali skalo. Krajišče,
-kjer je trak statično vpet, imenujemo [statična stran](/staticna-stran),
-krajišče, kjer ga napenjamo, pa [napenjalna stran](/napenjalna-stran). Dostop na
-visokico je praviloma z napenjalne strani.
+Visokica je sestavljena iz dveh [sidrišč](sidrisce), med katerima je razpet [trak](trak). Za sidrišča se navadno uporabi močna drevesa ali skalo. Krajišče, kjer je trak statično vpet, imenujemo [statična stran](staticna-stran), krajišče, kjer ga napenjamo, pa [napenjalna stran](napenjalna-stran). Dostop na visokico je praviloma z napenjalne strani.
 
-Za daljše visokice (od 100 m naprej) uporabljamo namesto enega samega kosa traku
-[segmentirane](/segmentiranje) trakove. Ta pristop zmanjša globino padca ob
-morebitni odpovedi dela [glavnega traku](/glavni-trak), olajša prenašanje opreme
-in omogoči sestavljanja opreme različnih lastnikov.
+Za daljše visokice (od 100 m naprej) uporabljamo namesto enega samega kosa traku [segmentirane](segmentiranje) trakove. Ta pristop zmanjša globino padca ob morebitni odpovedi dela [glavnega traku](glavni-trak), olajša prenašanje opreme in omogoči sestavljanja opreme različnih lastnikov.
 
 ## Varnost
 
-Za zagotovitev varnosti morajo biti vsi podsistemi visokice
-[redundantni](/redundanca). To botruje tudi značilnemu videzu visokice, saj je
-pod [glavnim trakom](/glavni-trak) v zankah obešen še
-[pomožni trak](/pomozni-trak). Primerno zavarovan mora biti tudi dostop do
-visokice: dostopna točka je namreč v večini primerov nad prepadom, zato se je
-treba med privezovanjem na [vis](/vis) začasno vpeti na varovalno vrv, privezano
-na [sidrišče](/sidrisce).
+Za zagotovitev varnosti morajo biti vsi podsistemi visokice [redundantni](redundanca). To botruje tudi značilnemu videzu visokice, saj je pod [glavnim trakom](glavni-trak) v zankah obešen še [pomožni trak](pomozni-trak). Primerno zavarovan mora biti tudi dostop do visokice: dostopna točka je namreč v večini primerov nad prepadom, zato se je treba med privezovanjem na [vis](vis) začasno vpeti na varovalno vrv, privezano na [sidrišče](sidrisce).
 
-Visokovalec ali visokovalka mora neposredno pred vsakim dostopom na visokico
-pozorno pregledati svoj plezalni pas ter oba vozla na [visu](/vis). Pas mora
-biti ustrezno zategnjen, vis mora biti vdet skozi obe glavni zanki na pasu, oba
-vozla na visu pa pravilno zavezana. Da zmanjšamo možnost človeške napake, je
-priporočeno, da nato isto opremo vedno pregleda še ena neodvisna oseba.
+Visokovalec ali visokovalka mora neposredno pred vsakim dostopom na visokico pozorno pregledati svoj plezalni pas ter oba vozla na [visu](vis). Pas mora biti ustrezno zategnjen, vis mora biti vdet skozi obe glavni zanki na pasu, oba vozla na visu pa pravilno zavezana. Da zmanjšamo možnost človeške napake, je priporočeno, da nato isto opremo vedno pregleda še ena neodvisna oseba.

--- a/src/wiki/vponka.md
+++ b/src/wiki/vponka.md
@@ -1,14 +1,3 @@
 # Vponka
 
-_Vponka_ je kovinski vezni člen ovalne ali hruškaste oblike, ki se na eni
-stranici zapira z vratci. Vratca so lahko prosto gibljiva ali pa imajo varnostno
-zaporo z matico. Od vseh kovinskih veznih členov je vpenjanje v vponko
-najhitrejše in najpreprostejše. V visokovanju vponke uporabljamo predvsem kot
-delovno opremo pri [postavljanju](/postavljanje) ter za pripenjanje varnostne
-popkovine med privezovanjem na [vis](/vis). Na [sidriščih](/sidrisce) jih
-srečamo le redko, in sicer zaradi njihove glavne slabosti: zasnovane so namreč
-le za obremenitev v eni smeri - vzdolž daljše stranice - in zato ne prenašajo
-dobro ne prečnih ne [trosmernih](/trosmerna-obremenitev) (oziroma večsmernih)
-obremenitev. Če vponko že uporabimo kot nosilni element, mora biti nujno
-izdelana iz jekla, saj aluminij dolgoročno ni odporen na ciklične obremenitve,
-ki jim je oprema izpostavljena pri visokovanju.
+_Vponka_ je kovinski vezni člen ovalne ali hruškaste oblike, ki se na eni stranici zapira z vratci. Vratca so lahko prosto gibljiva ali pa imajo varnostno zaporo z matico. Od vseh kovinskih veznih členov je vpenjanje v vponko najhitrejše in najpreprostejše. V visokovanju vponke uporabljamo predvsem kot delovno opremo pri [postavljanju](postavljanje) ter za pripenjanje varnostne popkovine med privezovanjem na [vis](vis). Na [sidriščih](sidrisce) jih srečamo le redko, in sicer zaradi njihove glavne slabosti: zasnovane so namreč le za obremenitev v eni smeri – vzdolž daljše stranice – in zato ne prenašajo dobro ne prečnih ne [trosmernih](trosmerna-obremenitev) (oziroma večsmernih) obremenitev. Če vponko že uporabimo kot nosilni element, mora biti nujno izdelana iz jekla, saj aluminij dolgoročno ni odporen na ciklične obremenitve, ki jim je oprema izpostavljena pri visokovanju.

--- a/src/wiki/vrvni-skopec.md
+++ b/src/wiki/vrvni-skopec.md
@@ -1,25 +1,9 @@
 # Vrvni škopec
 
-_Vrvni škopec_ je vezni člen, ki ima podobne lastnosti kot [škopec](/skopec),
-vendar je za razliko od slednjega izdelan iz vrvi in zato gibek. Za vrvne škopce
-se uporablja ohlapno pletena vrv iz
-[UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (bolj poznana pod blagovnim
-imenom Dyneema). Na eni strani škopca je vrv vdeta skozi samo sebe, s čimer
-oblikuje kratko zanko, na drugi strani pa sta konca vrvi spletena v debel vozel.
-Škopec zapremo tako, da zavozlani konec vstavimo skozi zanko, ki se že ob
-najmanjši obremenitvi zadrgne in prepreči, da bi vozel zdrsel nazaj skoznjo.
+_Vrvni škopec_ je vezni člen, ki ima podobne lastnosti kot [škopec](skopec), vendar je za razliko od slednjega izdelan iz vrvi in zato gibek. Za vrvne škopce se uporablja ohlapno pletena vrv iz [UHMWPE](https://en.wikipedia.org/wiki/UHMWPE) (bolj poznana pod blagovnim imenom Dyneema). Na eni strani škopca je vrv vdeta skozi samo sebe, s čimer oblikuje kratko zanko, na drugi strani pa sta konca vrvi spletena v debel vozel. Škopec zapremo tako, da zavozlani konec vstavimo skozi zanko, ki se že ob najmanjši obremenitvi zadrgne in prepreči, da bi vozel zdrsel nazaj skoznjo.
 
 ![Vrvni škopec](images/softshackle.jpg)
 
-Glavna prednost vrvnega škopca pred kovinskim je, da je mnogo lažji in ga je
-zato lažje prenašati. Poleg tega predstavlja manjšo nevarnost v primeru, da ob
-odpovedi kakega drugega veznega člena z veliko hitrostjo odleti v človeka.
-Glavni pomanjkljivosti sta neodpornost na abrazijo (preko obremenjenega vrvnega
-škopca _nikoli_ ne smemo vleči vrvi ali trakov) ter teoretična možnost, da se
-neobremenjen vrvni škopec sam odpre, če je izpostavljen tresljajem. V praksi so
-vrvni škopci vedno podvrženi vsaj majhni obremenitvi, zato do odprtja ne pride;
-za vsak slučaj pa v primeru dvoma njihovo zanko vseeno ovijemo še z lepilnim
-trakom.
+Glavna prednost vrvnega škopca pred kovinskim je, da je mnogo lažji in ga je zato lažje prenašati. Poleg tega predstavlja manjšo nevarnost v primeru, da ob odpovedi kakega drugega veznega člena z veliko hitrostjo odleti v človeka. Glavni pomanjkljivosti sta neodpornost na abrazijo (preko obremenjenega vrvnega škopca _nikoli_ ne smemo vleči vrvi ali trakov) ter teoretična možnost, da se neobremenjen vrvni škopec sam odpre, če je izpostavljen tresljajem. V praksi so vrvni škopci vedno podvrženi vsaj majhni obremenitvi, zato do odprtja ne pride; za vsak slučaj pa v primeru dvoma njihovo zanko vseeno ovijemo še z lepilnim trakom.
 
-Vrvni škopec je v visokovanju še zlasti nepogrešljiv pri sestavljanju
-[segmentiranih](/segmentiranje) trakov.
+Vrvni škopec je v visokovanju še zlasti nepogrešljiv pri sestavljanju [segmentiranih](segmentiranje) trakov.

--- a/src/wiki/vstajanje.md
+++ b/src/wiki/vstajanje.md
@@ -1,82 +1,23 @@
 # Vstajanje
 
-_Vstajanje_ na trak iz sedečega položaja in brez pomoči tal je ena od osnovnih
-veščin, ki so potrebne za hojo po [visokici](/visokica). Spodaj so opisani trije
-najpogosteje uporabljani načini. Pri vseh načinih pričnemo tako, da sedimo
-okobal na traku. Trak naj bo malenkost odmaknjen na eno stran, saj sicer
-pritisne naravnost na trtico, kar je precej boleče in neudobno. Z poskušanjem se
-ga hitro naučimo namestiti na mišice ob sedalni kosti, ki tak pritisk dobro
-prenašajo.
+_Vstajanje_ na trak iz sedečega položaja in brez pomoči tal je ena od osnovnih veščin, ki so potrebne za hojo po [visokici](visokica). Spodaj so opisani trije najpogosteje uporabljani načini. Pri vseh načinih pričnemo tako, da sedimo okobal na traku. Trak naj bo malenkost odmaknjen na eno stran, saj sicer pritisne naravnost na trtico, kar je precej boleče in neudobno. Z poskušanjem se ga hitro naučimo namestiti na mišice ob sedalni kosti, ki tak pritisk dobro prenašajo.
 
 ## Vstajanje iz sedé
 
-Vstajanje iz sede velja za "zlati standard". Ker je treba prehod v čepeči
-položaj izvesti hitro, ta način vstajanja sicer ni najlažji, a se z njim
-izognemo nekaterim slabim lastnostim drugih načinov. Zato ga vseeno priporočamo
-kot prvo izbiro pri učenju.
+Vstajanje iz sede velja za "zlati standard". Ker je treba prehod v čepeči položaj izvesti hitro, ta način vstajanja sicer ni najlažji, a se z njim izognemo nekaterim slabim lastnostim drugih načinov. Zato ga vseeno priporočamo kot prvo izbiro pri učenju.
 
-Stopali najprej položimo na trak pred seboj. Stopalo, ki je bliže telesu,
-zasukamo vstran in navzdol - trak poteka počez pod stopalom, blizu pete. Drugo
-stopalo postavimo pred prvo in ga poravnamo s smerjo traku. Obe stopali sta kar
-se da blizu telesu, saj to olajša vstajanje. Koleni razmaknemo, da si naredimo
-prostor, roke držimo razširjene, kot pri hoji po traku. Sedaj trup nagnemo
-naprej. Za nekatere ljudi je to že kar dovolj, da prenesejo težo na stopala. Če
-samo nagib ne zadostuje, si pomagamo z roko, in sicer se bodisi z njo odrinemo
-od traku za sabo bodisi se potegnemo za trak pred seboj. V obeh primerih naj bo
-stik roke s trakom čim krajši, saj ta položaj precej zmanjša možnosti za
-lovljenje ravnotežja. Po prenosu teže na stopala lahko za hip obmirujemo v
-čepečem položaju: ker je težišče telesa še vedno zelo blizu traku, je tak
-položaj precej stabilen in ga lahko izkoristimo za umiritev traku ter poravnavo
-telesa pred vstajanjem. Lahko pa prenos teže in vstajanje izvedemo tudi kot en
-sam zvezen gib.
+Stopali najprej položimo na trak pred seboj. Stopalo, ki je bliže telesu, zasukamo vstran in navzdol – trak poteka počez pod stopalom, blizu pete. Drugo stopalo postavimo pred prvo in ga poravnamo s smerjo traku. Obe stopali sta kar se da blizu telesu, saj to olajša vstajanje. Koleni razmaknemo, da si naredimo prostor, roke držimo razširjene, kot pri hoji po traku. Sedaj trup nagnemo naprej. Za nekatere ljudi je to že kar dovolj, da prenesejo težo na stopala. Če samo nagib ne zadostuje, si pomagamo z roko, in sicer se bodisi z njo odrinemo od traku za sabo bodisi se potegnemo za trak pred seboj. V obeh primerih naj bo stik roke s trakom čim krajši, saj ta položaj precej zmanjša možnosti za lovljenje ravnotežja. Po prenosu teže na stopala lahko za hip obmirujemo v čepečem položaju: ker je težišče telesa še vedno zelo blizu traku, je tak položaj precej stabilen in ga lahko izkoristimo za umiritev traku ter poravnavo telesa pred vstajanjem. Lahko pa prenos teže in vstajanje izvedemo tudi kot en sam zvezen gib.
 
 ![Sit start](images/sitstart.jpg)
 
 ## Vstajanje s spuščenim kolenom
 
-Vstajanje s spuščenim kolenom je nekoliko podobno vstajanju na Chongo in nudi
-podobno stabilnost, vendar v primerjavi s slednjim bistveno manj obremeni
-koleno. Njegova slaba stran je, da se je ob težavah težko izviti iz položaja,
-zato je padec pri spodletelem poskusu vstajanja manj nadzorovan, kar dela ta
-način manj primeren za vadbo v parku. V odsotnosti bližine tal ta lastnost ni
-tako problematična, zato je na visokicah ta način vstajanja precej pogostejši.
+Vstajanje s spuščenim kolenom je nekoliko podobno vstajanju na Chongo in nudi podobno stabilnost, vendar v primerjavi s slednjim bistveno manj obremeni koleno. Njegova slaba stran je, da se je ob težavah težko izviti iz položaja, zato je padec pri spodletelem poskusu vstajanja manj nadzorovan, kar dela ta način manj primeren za vadbo v parku. V odsotnosti bližine tal ta lastnost ni tako problematična, zato je na visokicah ta način vstajanja precej pogostejši.
 
-Da dosežemo izhodiščni položaj za to vrsto vstajanja, se najprej nagnemo močno
-naprej in eno od stopal z nartom navzdol naslonimo na trak za seboj. Nato se
-vzravnamo in pomaknemo nazaj po traku, dokler ne obsedimo na stopalu. Ker v tem
-položaju trak močno pritiska na nart, je lahko prvih nekaj poskusov precej
-bolečih, a z nekaj vaje se naučimo obremeniti pravo mesto in pritisku traku
-komaj še posvečamo kaj pozornosti. Roko, ki je na isti strani telesa kot
-stopalo, na katerem sedimo, iztegnemo vstran kot pri hoji, nasprotno roko pa
-prislonimo na trak tik pred seboj in si z njo pomagamo k vzravnani drži. Sedaj
-drugo nogo dvignemo predse in jo položimo na trak. V trenutku, ko to storimo, z
-roko izpustimo trak in pričnemo loviti ravnotežje z obema rokama. Ta položaj je
-zelo stabilen in lahko v njem nekaj časa počakamo. Nato pričnemo z vstajanjem,
-pri katerem večji delež dela opravi prednja noga. Ko smo opravili približno dve
-tretjini vstajanja, večino teže prenesemo na prednjo nogo, zadnje stopalo hitro
-obrnemo v pokončen položaj, z njim stopimo nazaj na trak ter v tem položaju
-dokončamo vstajanje
+Da dosežemo izhodiščni položaj za to vrsto vstajanja, se najprej nagnemo močno naprej in eno od stopal z nartom navzdol naslonimo na trak za seboj. Nato se vzravnamo in pomaknemo nazaj po traku, dokler ne obsedimo na stopalu. Ker v tem položaju trak močno pritiska na nart, je lahko prvih nekaj poskusov precej bolečih, a z nekaj vaje se naučimo obremeniti pravo mesto in pritisku traku komaj še posvečamo kaj pozornosti. Roko, ki je na isti strani telesa kot stopalo, na katerem sedimo, iztegnemo vstran kot pri hoji, nasprotno roko pa prislonimo na trak tik pred seboj in si z njo pomagamo k vzravnani drži. Sedaj drugo nogo dvignemo predse in jo položimo na trak. V trenutku, ko to storimo, z roko izpustimo trak in pričnemo loviti ravnotežje z obema rokama. Ta položaj je zelo stabilen in lahko v njem nekaj časa počakamo. Nato pričnemo z vstajanjem, pri katerem večji delež dela opravi prednja noga. Ko smo opravili približno dve tretjini vstajanja, večino teže prenesemo na prednjo nogo, zadnje stopalo hitro obrnemo v pokončen položaj, z njim stopimo nazaj na trak ter v tem položaju dokončamo vstajanje
 
 ## Vstajanje na Chongo
 
-Ta tehnika vstajanja je zelo stabilna in se je je enostavno naučiti, jo pa
-vseeno omenjamo zadnjo, ker je bilo ugotovljeno, da pri mnogih ljudeh
-preobremeni koleno in sčasoma privede do bolečin ter poškodb. Priporočamo
-previdnost.
+Ta tehnika vstajanja je zelo stabilna in se je je enostavno naučiti, jo pa vseeno omenjamo zadnjo, ker je bilo ugotovljeno, da pri mnogih ljudeh preobremeni koleno in sčasoma privede do bolečin ter poškodb. Priporočamo previdnost.
 
-V izhodiščni položaj za vstajanje na Chongo pridemo tako, da se nagnemo močno
-naprej in eno od stopal položimo na trak za seboj. Nato se vzravnamo in hkrati
-pomikamo po traku nazaj, dokler ne obsedimo na svoji peti. Stopalo pod nami je
-pri tem usmerjeno navzdol ter zasukano skoraj pravokotno glede na smer
-vstajanja, trak pa poteka počez po stopalu, tik pred peto. Roko, ki je na isti
-strani telesa kot stopalo, na katerem sedimo, iztegnemo vstran kot pri hoji,
-nasprotno roko pa prislonimo na trak tik pred seboj in si z njo pomagamo k
-vzravnani drži. V tem položaju se razkrije, ali je tehnika vstajanja na Chongo
-sploh primerna za nas. Teža zgornjega dela telesa se mora na peto prenašati
-_izključno_ preko stika s sedalno kostjo. Če je med peto in zadnjico že _samo
-najmanjša špranja_, se znaten delež sile prenese preko kolena, kar na dolgi rok
-privede do poškodb sklepa. V primeru, da lahko stabilno sedemo na peto,
-nadaljujemo: drugo nogo dvignemo predse in jo položimo na trak. V trenutku, ko
-to storimo, z roko izpustimo trak in pričnemo loviti ravnotežje z obema rokama.
-Telo pomaknemo naprej, da razporedimo težo po obeh nogah, nato pa počasi
-vstanemo.
+V izhodiščni položaj za vstajanje na Chongo pridemo tako, da se nagnemo močno naprej in eno od stopal položimo na trak za seboj. Nato se vzravnamo in hkrati pomikamo po traku nazaj, dokler ne obsedimo na svoji peti. Stopalo pod nami je pri tem usmerjeno navzdol ter zasukano skoraj pravokotno glede na smer vstajanja, trak pa poteka počez po stopalu, tik pred peto. Roko, ki je na isti strani telesa kot stopalo, na katerem sedimo, iztegnemo vstran kot pri hoji, nasprotno roko pa prislonimo na trak tik pred seboj in si z njo pomagamo k vzravnani drži. V tem položaju se razkrije, ali je tehnika vstajanja na Chongo sploh primerna za nas. Teža zgornjega dela telesa se mora na peto prenašati _izključno_ preko stika s sedalno kostjo. Če je med peto in zadnjico že _samo najmanjša špranja_, se znaten delež sile prenese preko kolena, kar na dolgi rok privede do poškodb sklepa. V primeru, da lahko stabilno sedemo na peto, nadaljujemo: drugo nogo dvignemo predse in jo položimo na trak. V trenutku, ko to storimo, z roko izpustimo trak in pričnemo loviti ravnotežje z obema rokama. Telo pomaknemo naprej, da razporedimo težo po obeh nogah, nato pa počasi vstanemo.

--- a/src/wiki/za-zacetnike.md
+++ b/src/wiki/za-zacetnike.md
@@ -1,41 +1,17 @@
 # Za začetnike
 
-Tako torej. Mika te visokovanje. Kaj pa zdaj? Prva in najpomembnejša stvar je,
-da se tega nikakor _ne lotevaš na lastno pest_. Vsaka napaka se lahko konča z
-izgubo življenja. Varno visokovanje zahteva znanje in pristope, ki se jih lahko
-naučiš le tako, da se pridružiš ekipi, ki jih že ima. Seveda pa je dobro najprej
-narediti domačo nalogo in se poučiti o zadevah. Upamo, da ti bo ta priročnik
-pomagal pri tem. Predlagamo, da si najprej po dolgem in počez prebereš to stran,
-nadaljuješ s [spletnimi viri](/spletni-viri), naposled pa se za svojo prvo pravo
-priložnost pozanimaš pri [visokovalski skupnosti](/skupnost). In seveda, da
-medtem uriš svoje spretnosti na varen način - v parku.
+Tako torej. Mika te visokovanje. Kaj pa zdaj? Prva in najpomembnejša stvar je, da se tega nikakor _ne lotevaš na lastno pest_. Vsaka napaka se lahko konča z izgubo življenja. Varno visokovanje zahteva znanje in pristope, ki se jih lahko naučiš le tako, da se pridružiš ekipi, ki jih že ima. Seveda pa je dobro najprej narediti domačo nalogo in se poučiti o zadevah. Upamo, da ti bo ta priročnik pomagal pri tem. Predlagamo, da si najprej po dolgem in počez prebereš to stran, nadaljuješ s [spletnimi viri](spletni-viri), naposled pa se za svojo prvo pravo priložnost pozanimaš pri [visokovalski skupnosti](skupnost). In seveda, da medtem uriš svoje spretnosti na varen način – v parku.
 
 ## Potrebno predznanje
 
-Visokovanje je fizično, predvsem pa psihično naporno, zato je treba biti pred
-prvim poskusom ustrezno pripravljen. Iskreno oceni svoje veščine. Tudi če že
-znaš hoditi po traku, bodo tvoje sposobnosti ob pogledu v globino verjetno na
-mah izpuhtele, kar pomeni, da se visokovanja še nima smisla lotevati, če je že
-tvoja hoja v parku negotova. Tule je zbranih nekaj predpogojev za uspešno
-srečanje z visokovanjem.
+Visokovanje je fizično, predvsem pa psihično naporno, zato je treba biti pred prvim poskusom ustrezno pripravljen. Iskreno oceni svoje veščine. Tudi če že znaš hoditi po traku, bodo tvoje sposobnosti ob pogledu v globino verjetno na mah izpuhtele, kar pomeni, da se visokovanja še nima smisla lotevati, če je že tvoja hoja v parku negotova. Tule je zbranih nekaj predpogojev za uspešno srečanje z visokovanjem.
 
-- Sposobnost v parku prehoditi trak dolžine okoli 30 metrov. Visokic, krajših od te razdalje, se praktično nikoli ne postavlja, saj bi bil padec nanje preveč sunkovit. Trak, na katerem vadiš, naj tudi ne bo preveč napet: običajno imajo visokice razmerje med povesom (na sredini) in dolžino med 1:10 in 1:15. Pri 30-metrskem traku to pomeni med 2 m in 3 m povesa. Če običajno vadiš na bolj napetem traku, tvoje telo ne bo pripravljeno na dinamiko visokice. A previdno pri vadbi – če si krajišča postaviš tako visoko, nikar ne hodi preblizu njih. Nočemo, da se polomiš, še preden se sploh srečamo!
-- Sposobnost [dviga na trak](/dvig-na-trak) iz visečega položaja. Na visokici ni tal, s katerimi bi si bilo moč pomagati pri vstajanju, in po vsakem padcu se je treba znati povzpeti nazaj. Manever je dokaj preprost, ko ga enkrat obvladaš, je pa zanj potrebne nekaj vaje. Vadiš lahko tako, da si v parku napneš trak dovolj visoko, da ko se zanj primeš z rokami ter zatakneš z nogo, obvisiš pod njim. Če vadiš na traku s predlaganimi razmerji (dolžina okoli 30 m in krajišča od 2 m do 3 m visoko) bo to tako ali tako najpriročnejši način za priti nanj.
-- Sposobnost [vstajanja](/vstajanje) iz sedečega položaja. Tudi to lahko vadiš v parku. Začni na kratkih in nizkih trakovih. Če te je strah padca (zlasti neprijeten in nevaren je padec na hrbet), za začetek poprosi kakega prijatelja, da stoji ob tebi, pripravljen, da te prestreže.
+* Sposobnost v parku prehoditi trak dolžine okoli 30 metrov. Visokic, krajših od te razdalje, se praktično nikoli ne postavlja, saj bi bil padec nanje preveč sunkovit. Trak, na katerem vadiš, naj tudi ne bo preveč napet: običajno imajo visokice razmerje med povesom (na sredini) in dolžino med 1:10 in 1:15. Pri 30-metrskem traku to pomeni med 2 m in 3 m povesa. Če običajno vadiš na bolj napetem traku, tvoje telo ne bo pripravljeno na dinamiko visokice. A previdno pri vadbi – če si krajišča postaviš tako visoko, nikar ne hodi preblizu njih. Nočemo, da se polomiš, še preden se sploh srečamo!
+* Sposobnost [dviga na trak](dvig-na-trak) iz visečega položaja. Na visokici ni tal, s katerimi bi si bilo moč pomagati pri vstajanju, in po vsakem padcu se je treba znati povzpeti nazaj. Manever je dokaj preprost, ko ga enkrat obvladaš, je pa zanj potrebne nekaj vaje. Vadiš lahko tako, da si v parku napneš trak dovolj visoko, da ko se zanj primeš z rokami ter zatakneš z nogo, obvisiš pod njim. Če vadiš na traku s predlaganimi razmerji (dolžina okoli 30 m in krajišča od 2 m do 3 m visoko) bo to tako ali tako najpriročnejši način za priti nanj.
+* Sposobnost [vstajanja](vstajanje) iz sedečega položaja. Tudi to lahko vadiš v parku. Začni na kratkih in nizkih trakovih. Če te je strah padca (zlasti neprijeten in nevaren je padec na hrbet), za začetek poprosi kakega prijatelja, da stoji ob tebi, pripravljen, da te prestreže.
 
 ## Potrebna oprema
 
-Če meniš, da imaš potrebne sposobnosti, je čas za naslednji korak. Kaj
-potrebuješ pri svojem prvem visokovanju? Najkrajši odgovor je: nič. Nekoliko
-daljši odgovor je: dobro voljo in pripravljenost pomagati. Če že hočeš prinesti
-kak kos opreme, prinesi plezalni pas, če ga imaš. Če so se te zgoraj napisana
-vodila prijela, veš, da bodo za začetek visokico zate postavili izkušeni
-visokovalci, ki že imajo vso potrebno opremo. Je pa prijazno in pričakovano, da
-se jim kako oddolžiš. Lahko se ponudiš za prevoz. Lahko neseš nahrbtnik z
-opremo. Lahko prineseš hrano in pijačo. Lahko pomagaš pri postavljanju,
-fotografiraš, igraš na inštrument, vzpodbujaš, ustvarjaš dobro vzdušje. Če
-pokažeš svojo pripravljenost prispevati k dogodku, te bodo visokovalci vedno
-radi imeli v svoji družbi.
+Če meniš, da imaš potrebne sposobnosti, je čas za naslednji korak. Kaj potrebuješ pri svojem prvem visokovanju? Najkrajši odgovor je: nič. Nekoliko daljši odgovor je: dobro voljo in pripravljenost pomagati. Če že hočeš prinesti kak kos opreme, prinesi plezalni pas, če ga imaš. Če so se te zgoraj napisana vodila prijela, veš, da bodo za začetek visokico zate postavili izkušeni visokovalci, ki že imajo vso potrebno opremo. Je pa prijazno in pričakovano, da se jim kako oddolžiš. Lahko se ponudiš za prevoz. Lahko neseš nahrbtnik z opremo. Lahko prineseš hrano in pijačo. Lahko pomagaš pri postavljanju, fotografiraš, igraš na inštrument, vzpodbujaš, ustvarjaš dobro vzdušje. Če pokažeš svojo pripravljenost prispevati k dogodku, te bodo visokovalci vedno radi imeli v svoji družbi.
 
-Če si prišel ali prišla do te točke, nadaljnjih navodil ne potrebuješ: ob pravem
-času bodo prišla v nepisani obliki, tako kot vedno poteka pravo učenje. Srečno!
+Če si prišel ali prišla do te točke, nadaljnjih navodil ne potrebuješ: ob pravem času bodo prišla v nepisani obliki, tako kot vedno poteka pravo učenje. Srečno!


### PR DESCRIPTION
Vsa vsebina wikija še enkrat pretvorena s pythonom in regexi, ker je prejšnja pretvorba za seboj pustila nekaj težav. Datoteke sem na koncu ročno poenotil z zadnjimi različicami iz git repozitorija, tako da so zadnji popravki besedila tudi vključeni. Nove datoteke nimajo statičnega preloma vrstic (tj. zdaj je en sam `\n` na vsak odstavek) , ker po mojem mnenju statični prelom prinese več problemov kot koristi.